### PR TITLE
U-24 | Add auto completion suggestion query

### DIFF
--- a/graphql/src/index.ts
+++ b/graphql/src/index.ts
@@ -75,6 +75,24 @@ const resolvers = {
 
       return { es_results: [result], edges, hits, connectionArguments };
     },
+    unifiedSearchCompletionSuggestions: async (
+      _source: any,
+      { prefix, languages, index, size }: any,
+      { dataSources }: any
+    ) => {
+      const res = await dataSources.elasticSearchAPI.getSuggestions(
+        prefix,
+        languages,
+        index,
+        size
+      );
+
+      return {
+        suggestions: res.suggest.suggestions[0].options.map((option) => ({
+          label: option.text,
+        })),
+      };
+    },
   },
   SearchResultConnection: {
     count({ hits }: any) {

--- a/graphql/src/schemas/query.ts
+++ b/graphql/src/schemas/query.ts
@@ -14,6 +14,12 @@ export const querySchema = `
     SERVICE
   }
 
+  enum UnifiedSearchLanguage {
+    FINNISH
+    SWEDISH
+    ENGLISH
+  }
+
   type SearchResultConnection {
     """ Elasticsearch raw results """
     es_results: [ElasticSearchResult]
@@ -41,6 +47,14 @@ export const querySchema = `
     id: ID!
     venue: Venue
     searchCategories: [UnifiedSearchResultCategory!]!
+  }
+
+  type Suggestion {
+    label: String!
+  }
+
+  type SearchSuggestionConnection {
+    suggestions: [Suggestion]!
   }
 
   type Query {
@@ -85,5 +99,27 @@ export const querySchema = `
         last: Int
 
       ): SearchResultConnection
+
+    unifiedSearchCompletionSuggestions(
+      """
+      Free form query string, corresponding to what the user has typed so far
+      """
+      prefix: String
+
+      """
+      Required parameter that target
+      """
+      languages: [UnifiedSearchLanguage!]! = [FINNISH, SWEDISH, ENGLISH]
+
+      """
+      Optional search index.
+      """
+      index: String
+
+      """
+      Optional result size.
+      """
+      size: Int = 5
+      ): SearchSuggestionConnection
   }
 `;

--- a/sources/ingest/fetch/location.py
+++ b/sources/ingest/fetch/location.py
@@ -7,6 +7,8 @@ from django.conf import settings
 import json
 import sys
 import logging
+import base64
+import functools
 
 from elasticsearch import Elasticsearch
 
@@ -64,6 +66,11 @@ class OpeningHours:
     hourLines: List[LanguageString] = field(default_factory=list)
 
 @dataclass
+class OntologyObject:
+    id: str
+    label: LanguageString
+
+@dataclass
 class Venue:
     meta: NodeMeta = None
     name: LanguageString = None
@@ -86,6 +93,7 @@ class Venue:
 class Root:
     venue: Venue
     links: List[LinkedData] = field(default_factory=list)
+    suggest: List[str] = field(default_factory=list)
 
 
 def get_tpr_units():
@@ -121,11 +129,96 @@ def get_opening_hours(d):
     return results
 
 
+def prefix_and_mask(prefix, body):
+    message = f"{prefix}-{body}"
+    message_bytes = message.encode("utf-8")
+    base64_bytes = base64.b64encode(message_bytes)
+
+    return base64_bytes.decode("utf-8")
+
+
+def get_ontologywords_as_ontologies(ontologywords):
+    ontologies = []
+
+    for ontologyword in ontologywords:
+        ontologies.append(
+            OntologyObject(
+                id=str(ontologyword.get("id")),
+                label=create_language_string(ontologyword, "ontologyword")
+            )
+        )
+
+        if (
+            "extra_searchwords_fi" in ontologyword
+            or "extra_searchwords_sv" in ontologyword
+            or "extra_searchwords_en" in ontologyword
+        ):
+            ontologies.append(
+                OntologyObject(
+                    # A unique id is not available in the source data. To make the id
+                    # more opaque we are encoding it.
+                    id=prefix_and_mask("es-", ontologyword.get("id")),
+                    label=create_language_string(ontologyword, "extra_searchwords")
+                )
+            )
+
+    return ontologies
+
+
+def get_ontologytree_as_ontologies(ontologytree):
+    ontologies = []
+
+    for ontologybranch in ontologytree:
+        ontologies.append(
+            OntologyObject(
+                id=str(ontologybranch.get("id")),
+                label=create_language_string(ontologybranch, "name")
+            )
+        )
+
+        if (
+            "extra_searchwords_fi" in ontologybranch
+            or "extra_searchwords_sv" in ontologybranch
+            or "extra_searchwords_en" in ontologybranch
+        ):
+            ontologies.append(
+                OntologyObject(
+                    # A unique id is not available in the source data. To make the id
+                    # more opaque we are encoding it.
+                    id=prefix_and_mask("es-", ontologybranch.get("id")),
+                    label=create_language_string(ontologybranch, "extra_searchwords")
+                )
+            )
+
+    return ontologies
+
+
+custom_mappings = {
+    "properties": {
+        "suggest": {    
+            "type": "completion"
+        }
+    }
+}
+
 def fetch():
     try:
         es = Elasticsearch([settings.ES_URI])
     except ConnectionError as e:
         return "ERROR at {}".format(__name__)
+
+    logger.info("Creating index location")
+
+    try:
+        es.indices.create(index="location")
+    except:
+        logger.info("Index location already exists, skipping")
+
+    logger.info("Applying custom mapping")
+
+    es.indices.put_mapping(index="location", body=custom_mappings)
+
+    logger.info("Custom mapping set")
 
     logger.info("Requesting data at {}".format(__name__))
 
@@ -192,12 +285,32 @@ def fetch():
         # Extra information to raw data
         tpr_unit["origin"] = "tpr"
 
+        # TODO: Separate words from tree
+        all_ontologies = []
         # Ontology ID's and tree contain plain integers, get corresponding texts
         if tpr_unit.get("ontologyword_ids", None):
-            tpr_unit["ontologyword_ids_enriched"] = ontology.enrich_word_ids(tpr_unit["ontologyword_ids"])
+            word_ontologies = ontology.enrich_word_ids(tpr_unit["ontologyword_ids"])
+            tpr_unit["ontologyword_ids_enriched"] = word_ontologies
+            all_ontologies = all_ontologies + get_ontologywords_as_ontologies(word_ontologies)
 
         if tpr_unit.get("ontologytree_ids", None):
-            tpr_unit["ontologytree_ids_enriched"] = ontology.enrich_tree_ids(tpr_unit["ontologytree_ids"])
+            tree_ontologies = ontology.enrich_tree_ids(tpr_unit["ontologytree_ids"])
+            tpr_unit["ontologytree_ids_enriched"] = tree_ontologies
+            all_ontologies = all_ontologies + get_ontologytree_as_ontologies(tree_ontologies)
+
+        # TODO: Provide multilanguage support with context
+        ontology_labels = functools.reduce(
+            lambda acc, ontology: acc
+            + [
+                ontology.label.fi,
+                ontology.label.sv,
+                ontology.label.en,
+            ],
+            all_ontologies,
+            [],
+        )
+
+        root.suggest = ontology_labels
 
         link = LinkedData(
             service="tpr",
@@ -206,9 +319,9 @@ def fetch():
         root.links.append(link)
 
         r = es.index(index="location", doc_type="_doc", body=str(json.dumps(asdict(root))))
+
         logger.debug(f"Fethed data count: {count}")
         count = count + 1
-
 
     return "Fetch completed by {}".format(__name__)
 


### PR DESCRIPTION
This PR enables the completion suggestion query. It consists of three parts:

1. Amending the definition of the `location` index to include mappings the completion suggester requires
2. Changes to the data harvester script which make it collect and store suggestion data according to the new mappings
3. Adding a new query to the Graphql service which makes a suggestion query to elastic and returns a simplified version of the results

When you have `unified-search` running locally, you can test the auto suggester here: https://codesandbox.io/s/vigilant-chatelet-m1sft?file=/src/SearchForm.js

### Changes to the location index

In general elastic suggesters adopt the following form
```js
suggest: {
  suggestion-group: { // an arbitrary name for this suggestion result set
    prefix, // The string the suggestion is built based of
    [name-of-suggester]: { // Name of suggester
```

We would configure a [completion suggestor](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html#completion-suggester) like so:

```js
suggest: {
 completion-suggest: {
    prefix,
    completion: {
```

The completion suggestor has one mandatory field, named "field":

```
completion: {
  field: 'suggest',
```

This field must be of the type `completion`. Elastic fields can only have a single type at any given time. That's why it would be "violent" to transform some existing (or to-be-added) field's type which is currently (or will be) indexed.

This forces us to consider two options: either we index suggestion data in its own index in which case we don't alter the search performance of the actual search index. This approach may introduce some problems with keeping the data in sync. Another route, which is a less major change, is to add a new field to the current index. This field duplicates the index data we want to retain the original type for, and applies the `completion` type to the new field.

This PR uses the latter approach.

We add a custom mapping into the `location` index which defines the `suggest` field to be of type `completion`.

**Note about language**  

The index was also amended to define context for the `suggest` field. This allows each suggestion input to be given contextual information about the language the suggestion is in. In essence this allows search users to find suggestions in a specific language, or languages.

Context must be provided when it has been defined in the mappings. Therefore suggestions can't be made without providing the language context. Search users can provide all supported languages as the context if they want to return suggestions for all languages.

### Changes to the harvester

The harvester was slightly adjusted to store a suggestion field for documents within the `location` index.

I added the `Ontology` data structure we discussed briefly, but did not add ontologies to the venue object. This was s slight compromise because I wanted to avoid bloating this change set. Adding ontologies to the result set would have required solving these two problem: (1) separating word and tree ontolgoies and (2) limiting the depth of tree ontologies to a sensible level.

At the same time, the suggestion harvesting was sensible to implement in a way where suggestion data was uniform in order to avoid the need for refactoring later on. Hence I added the ontology data class now.

### Added a completion query

The Graphql API now supports completion queries:

```graphql
unifiedSearchCompletionSuggestions(
  prefix: String
  languages: [UnifiedSearchLanguage!]! = [FINNISH, SWEDISH, ENGLISH]
  index: String
  size: Int = 5
): SearchSuggestionConnection
```

Where `prefix` is the string we want to complete, `languages` control which languages are allowed in suggestions, `index` targets the index and `size` can be used to control the maximum amount of returned suggestions.

The Graphql API returns data like so:

```json
{
  "data": {
    "unifiedSearchCompletionSuggestions": {
      "suggestions": [
        {
          "label": "Dagverksamhet för äldre"
        },
        {
          "label": "Dagverksamhet inom vård av utvecklingsstörda"
        },
````

As a slight act of future proofing we've used an object for suggestions even though at the moment their content is only a single field. In theory it's possible to attach more data, for instance score, context or some fields from the source data.