### PR TITLE
Less verbose logging

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -22,7 +22,7 @@ env:
   K8S_REQUEST_RAM: 200Mi
   K8S_LIMIT_CPU: 300m
   K8S_LIMIT_RAM: 300Mi
-  DEBUG: 1
+  DEBUG: 0
 
 jobs:
   build:

--- a/sources/ingest/fetch/location.py
+++ b/sources/ingest/fetch/location.py
@@ -258,20 +258,20 @@ def fetch():
     except ConnectionError as e:
         return "ERROR at {}".format(__name__)
 
-    logger.info("Creating index location")
+    logger.debug("Creating index location")
 
     try:
         es.indices.create(index="location")
     except:
-        logger.info("Index location already exists, skipping")
+        logger.debug("Index location already exists, skipping")
 
-    logger.info("Applying custom mapping")
+    logger.debug("Applying custom mapping")
 
     es.indices.put_mapping(index="location", body=custom_mappings)
 
-    logger.info("Custom mapping set")
+    logger.debug("Custom mapping set")
 
-    logger.info("Requesting data at {}".format(__name__))
+    logger.debug("Requesting data at {}".format(__name__))
 
     ontology = Ontology()
 
@@ -309,19 +309,12 @@ def fetch():
             url=f"http://hauki-test.oc.hel.ninja/v1/resource/tprek:{_id}/opening_hours/",
             is_open_now_url=f"http://hauki-test.oc.hel.ninja/v1/resource/tprek:{_id}/is_open_now/")
 
-        # TODO, this data is usually missing
-        o = get_opening_hours(tpr_unit)
-        if o:
-            logger.debug(o)
-
         venue = Venue(
             name=create_language_string(tpr_unit, "name"),
             description=create_language_string(tpr_unit, "desc"),
             location=location, 
             meta=meta, 
             openingHours=opening_hours)
-
-        #print(tpr_unit)
 
         place_url, place = get_linkedevents_place(_id)
 
@@ -361,10 +354,9 @@ def fetch():
         root.links.append(link)
 
         r = es.index(index="location", doc_type="_doc", body=str(json.dumps(asdict(root))))
-
-        logger.debug(f"Fethed data count: {count}")
         count = count + 1
 
+    logger.info(f"Fetched {count} items in total")
     return "Fetch completed by {}".format(__name__)
 
 
@@ -373,7 +365,7 @@ def delete():
     try:
         es = Elasticsearch([settings.ES_URI])
         r = es.indices.delete(index="location")
-        logger.info(r)
+        logger.debug(r)
     except Exception as e:
         return "ERROR at {}".format(__name__)
 

--- a/sources/ingest/management/commands/ingest_data.py
+++ b/sources/ingest/management/commands/ingest_data.py
@@ -1,7 +1,11 @@
 from django.core.management.base import BaseCommand
 from django.utils import timezone
+import logging
 
 from ingest.fetch import servicemap, linkedevents, palvelukartta, location, vapaaehtoistoiminta
+
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -25,7 +29,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         time = timezone.now().strftime("%X")
-        print("It's now %s" % time)
+        logger.info("Started at %s" % time)
 
         # Provided by ingest.fetch, default unless specified on command line
         inds = {
@@ -42,7 +46,7 @@ class Command(BaseCommand):
             # Check validity
             for i in index_list:
                 if i not in inds.keys():
-                    print(f"Unknown index {i}, allowed: {inds.keys()}")
+                    logger.error(f"Unknown index {i}, allowed: {inds.keys()}")
                     return
 
             inds = {i: inds[i] for i in index_list}
@@ -50,14 +54,14 @@ class Command(BaseCommand):
         # delete indexes
         if kwargs["delete"]:
             for name, _obj in inds.items():
-                print(f"DELETING DATA at {name}")
+                logger.info(f"DELETING DATA at {name}")
                 _obj.delete()
             return
 
         # fetch indexes
         for name, _obj in inds.items():
-            print(f"Fetching {name}")
+            logger.info(f"Fetching {name}")
             _obj.fetch()
 
         time = timezone.now().strftime("%X")
-        print("Completed at %s" % time)
+        logger.info("Completed at %s" % time)

--- a/sources/sources/settings.py
+++ b/sources/sources/settings.py
@@ -25,9 +25,9 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 
 ES_URI = os.getenv("ES_URI")
 
-DEBUG = os.getenv("DEBUG")
+DEBUG = os.getenv("DEBUG", "false").lower() in ("yes", "true", "t", "1")
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "").split(",")
 
 
 # Application definition
@@ -145,7 +145,13 @@ LOGGING = {
         "django.request": {
             "handlers": ["console"],
             "propagate": False,
-            'level': 'DEBUG' if DEBUG else 'INFO',
+            'level': 'DEBUG' if DEBUG else 'WARNING',
         },
+        "elasticsearch": {
+            "handlers": ["console"],
+            "propagate": False,
+            'level': 'DEBUG' if DEBUG else 'WARNING',
+        },
+
     },
 }


### PR DESCRIPTION
Reduce verbosity of harvester logging:
- use debug logging instead of info in most cases
- prevent printing Elasticsearch API URL calls with ES specific logger config
- fix DEBUG env variable handling
- Disable debug logging in staging (similar to prod)