### PR TITLE
US-23 | GraphQL: results filtering based on language

### DIFF
--- a/graphql/src/constants.ts
+++ b/graphql/src/constants.ts
@@ -1,0 +1,5 @@
+export const GraphQlToElasticLanguageMap = {
+  FINNISH: 'fi',
+  SWEDISH: 'sv',
+  ENGLISH: 'en',
+} as const;

--- a/graphql/src/datasources/es.ts
+++ b/graphql/src/datasources/es.ts
@@ -21,14 +21,20 @@ class ElasticSearchAPI extends RESTDataSource {
     languages?: ElasticLanguage[]
   ) {
     const es_index = index ? index : this.defaultIndex;
+    const defaultQuery = {
+      multi_match: {
+        query: q,
+        fields: [
+          'venue.name.*',
+          'venue.description.*',
+          'links.raw_data.short_desc_*',
+        ],
+      },
+    };
 
     // Resolve query
     let query: any = {
-      query: {
-        query_string: {
-          query: q,
-        },
-      },
+      query: defaultQuery,
     };
 
     // Resolve ontology
@@ -39,11 +45,7 @@ class ElasticSearchAPI extends RESTDataSource {
         query: {
           bool: {
             must: [
-              {
-                query_string: {
-                  query: q,
-                },
-              },
+              defaultQuery,
               {
                 multi_match: {
                   query: ontology,

--- a/graphql/src/datasources/es.ts
+++ b/graphql/src/datasources/es.ts
@@ -25,10 +25,16 @@ class ElasticSearchAPI extends RESTDataSource {
       multi_match: {
         query: q,
         fields: [
-          'venue.name.*',
-          'venue.description.*',
-          'links.raw_data.short_desc_*',
-        ],
+          'venue.name.',
+          'venue.description.',
+          'links.raw_data.short_desc_',
+        ].reduce(
+          (acc, fieldPath) => [
+            ...acc,
+            ...targetFieldLanguages(fieldPath, languages),
+          ],
+          []
+        ),
       },
     };
 

--- a/graphql/src/schemas/query.ts
+++ b/graphql/src/schemas/query.ts
@@ -98,6 +98,11 @@ export const querySchema = `
         """
         last: Int
 
+        """
+        Targets the search to fields of specified language
+        """
+        languages: [UnifiedSearchLanguage!]! = [FINNISH, SWEDISH, ENGLISH]
+
       ): SearchResultConnection
 
     unifiedSearchCompletionSuggestions(

--- a/graphql/src/schemas/query.ts
+++ b/graphql/src/schemas/query.ts
@@ -107,7 +107,7 @@ export const querySchema = `
       prefix: String
 
       """
-      Required parameter that target
+      Limits the result set into the specified languages
       """
       languages: [UnifiedSearchLanguage!]! = [FINNISH, SWEDISH, ENGLISH]
 

--- a/graphql/src/types.ts
+++ b/graphql/src/types.ts
@@ -1,3 +1,5 @@
+import { GraphQlToElasticLanguageMap } from './constants';
+
 export type ConnectionCursor = string;
 
 export type ConnectionCursorObject = {
@@ -27,3 +29,5 @@ export type ElasticSearchPagination = {
   from?: number;
   size?: number;
 };
+
+export type ElasticLanguage = typeof GraphQlToElasticLanguageMap[keyof typeof GraphQlToElasticLanguageMap];

--- a/graphql/src/utils.ts
+++ b/graphql/src/utils.ts
@@ -1,7 +1,9 @@
+import { GraphQlToElasticLanguageMap } from './constants';
 import {
   ConnectionArguments,
   ElasticSearchPagination,
   ConnectionCursorObject,
+  ElasticLanguage,
 } from './types';
 
 export function createCursor<T>(query: T): string {
@@ -48,4 +50,24 @@ export function getEsOffsetPaginationQuery({
     from: offset,
     size,
   };
+}
+
+export function elasticLanguageFromGraphqlLanguage(
+  graphqlLanguages: string[]
+): ElasticLanguage[] {
+  return graphqlLanguages.map(
+    (language) => GraphQlToElasticLanguageMap[language]
+  );
+}
+
+export function targetFieldLanguages(
+  field: string,
+  languages: ElasticLanguage[]
+) {
+  // If all languages are targeted, use wildcard search
+  if (languages.length === Object.values(GraphQlToElasticLanguageMap).length) {
+    return [`${field}*`];
+  }
+
+  return languages.map((language) => `${field}${language}`);
 }


### PR DESCRIPTION
This PR changes which index fields are targeted based on the languages the API consumer is requesting.

As a part of this PR, we are changing how "search all" is defined. Instead of targeting all indexed fields ("*"), it now targets the following fields:

```
'venue.name',
'venue.description',
'links.raw_data.short_desc',
```

This change was done in order to tackle the increased amount of maintenance load that language support forced us to add.

To avoid targeting all languages, we have to limit the set of fields we target. We can only do this by "safelisting", i.e. listing all the fields we want to search from.

API consumers can now specify the `languages` parameter while making a `unifiedSearch` query to limit the queried fields to a language or languages.