### PR TITLE
US-23 | Fix searching with language

### DIFF
--- a/sources/ingest/fetch/location.py
+++ b/sources/ingest/fetch/location.py
@@ -237,6 +237,25 @@ def get_suggestions_from_ontologies(ontologies: List[OntologyObject]):
     return suggest
 
 
+def define_language_properties():
+    languages = [("fi", "finnish"), ("sv", "swedish"), ("en", "english")]
+    language_properties = {}
+
+    for [langauge, analyzer] in languages:
+        language_properties[langauge] = {
+            "type": "text",
+            "analyzer": analyzer,
+            "fields": {
+                "keyword": {
+                    "type": "keyword",
+                    "ignore_above" : 256
+                }
+            }
+        }
+
+    return language_properties
+
+
 custom_mappings = {
     "properties": {
         "suggest": {    
@@ -247,6 +266,16 @@ custom_mappings = {
                     "type": "category",
                 }
             ]
+        },
+        "venue": {
+            "properties": {
+                "name": {
+                    "properties": define_language_properties()
+                },
+                "description": {
+                    "properties": define_language_properties()
+                }
+            }
         }
     }
 }

--- a/sources/ingest/fetch/location.py
+++ b/sources/ingest/fetch/location.py
@@ -241,8 +241,8 @@ def define_language_properties():
     languages = [("fi", "finnish"), ("sv", "swedish"), ("en", "english")]
     language_properties = {}
 
-    for [langauge, analyzer] in languages:
-        language_properties[langauge] = {
+    for [language, analyzer] in languages:
+        language_properties[language] = {
             "type": "text",
             "analyzer": analyzer,
             "fields": {


### PR DESCRIPTION
This PR attempts to improve searches which have the language context. There are two changes.

### Adding language analyzer for venue fields

This PR adds the language analyzer for the venue's language aware fields.

These analyzers help elastic break down words into their unconjugated forms. For instance "Herttoniemi" will then match "Herttoniemen". Without these analyserzs the example would not be a match.

This change will decrease the amount of cases where "should be matches" are not matched due to the language context.

### Disallowing matches between languages

Changes into the query logic disallow such matches, where a match of one type in language A and a match in a second type in language B yield a match. For instance, when the searched string "Herttoniemi" matches an English description (with no other languages matching) and an ontology of "taide" matches a Finnish field (with no other matches). After this change such hits no longer match. In other words, the search and the ontology must match for a specific language. This makes the result behaviour more predictable.

In boolean logic searches should be matched something like so:

```
if
    search matches Finnish name AND search matches Finnish ontology
    OR search matches English name AND search matches English ontology
    ...
```