### PR TITLE
Ontology query for event index

### DIFF
--- a/graphql/src/datasources/es.ts
+++ b/graphql/src/datasources/es.ts
@@ -112,12 +112,10 @@ class ElasticSearchAPI extends RESTDataSource {
       ...query,
     };
 
-    const data = await this.post(`${es_index}/_search`, undefined, {
+    return this.post(`${es_index}/_search`, undefined, {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(query),
     });
-
-    return [data];
   }
 
   async getSuggestions(

--- a/graphql/src/datasources/es.ts
+++ b/graphql/src/datasources/es.ts
@@ -106,27 +106,15 @@ class ElasticSearchAPI extends RESTDataSource {
       };
     }
 
-    /*
-      const data = await this.post(`test-index/_search`, undefined,
-          {
-            headers: { 'Content-Type': 'application/json', },
-            body: JSON.stringify(query)
-          },
-      );
-    */
-
     // Resolve pagination
     query = {
       ...getEsOffsetPaginationQuery(connectionArguments),
       ...query,
     };
 
-    const data = this.post(`${es_index}/_search`, undefined, {
+    const data = await this.post(`${es_index}/_search`, undefined, {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(query),
-    }).then((r) => {
-      console.log(r.hits.hits[0]);
-      return r;
     });
 
     return [data];

--- a/graphql/src/datasources/es.ts
+++ b/graphql/src/datasources/es.ts
@@ -38,6 +38,24 @@ class ElasticSearchAPI extends RESTDataSource {
       return [];
     };
 
+    const ontologyFields = (lang: string, index: string) => {
+      if (index === 'location') {
+        return [
+          `links.raw_data.ontologyword_ids_enriched.extra_searchwords_${lang}`,
+          `links.raw_data.ontologyword_ids_enriched.ontologyword_${lang}`,
+          `links.raw_data.ontologytree_ids_enriched.name_${lang}`,
+          `links.raw_data.ontologytree_ids_enriched.extra_searchwords_${lang}`,
+        ]
+      }
+      else if (index === 'event') {
+        return [
+          `ontology.${lang}`,
+          `ontology.alt`,
+        ]
+      }
+      return [];
+    }
+
     const defaultQuery = languages.reduce(
       (acc, language) => ({
         ...acc,
@@ -62,20 +80,13 @@ class ElasticSearchAPI extends RESTDataSource {
 
     // Resolve ontology
     if (ontology) {
-      /* TODO, depends on index specific data types */
-
       const ontologyMatchers = languages.reduce(
         (acc, language) => ({
           ...acc,
           [language]: {
             multi_match: {
               query: ontology,
-              fields: [
-                `links.raw_data.ontologyword_ids_enriched.extra_searchwords_${language}`,
-                `links.raw_data.ontologyword_ids_enriched.ontologyword_${language}`,
-                `links.raw_data.ontologytree_ids_enriched.name_${language}`,
-                `links.raw_data.ontologytree_ids_enriched.extra_searchwords_${language}`,
-              ],
+              fields: ontologyFields(language, index),
             },
           },
         }),

--- a/graphql/src/index.ts
+++ b/graphql/src/index.ts
@@ -67,14 +67,13 @@ const resolvers = {
     ) => {
       const connectionArguments = { before, after, first, last };
 
-      const res = await dataSources.elasticSearchAPI.getQueryResults(
+      const result = await dataSources.elasticSearchAPI.getQueryResults(
         q,
         ontology,
         index,
         connectionArguments,
         elasticLanguageFromGraphqlLanguage(languages)
       );
-      const result = await res[0];
 
       const getCursor = (offset: number) =>
         createCursor<ConnectionCursorObject>({

--- a/sources/ingest/fetch/event.py
+++ b/sources/ingest/fetch/event.py
@@ -2,6 +2,7 @@ import requests
 import logging
 from dataclasses import dataclass, field, asdict
 from typing import List
+
 from django.conf import settings
 from datetime import datetime
 
@@ -41,6 +42,7 @@ class LinkedData:
 @dataclass
 class Root:
     event: Event
+    ontology: List[str] = field(default_factory=list)
     links: List[LinkedData] = field(default_factory=list)
     #suggest: List[str] = field(default_factory=list)
 
@@ -84,6 +86,8 @@ def fetch():
             )
 
             root = Root(event=event)
+
+            root.ontology = keyword.grouped_by_lang(entry["keywords"])
 
             event_data = LinkedData(
                 service="linkedevents",

--- a/sources/ingest/fetch/event.py
+++ b/sources/ingest/fetch/event.py
@@ -1,7 +1,7 @@
 import requests
 import logging
 from dataclasses import dataclass, field, asdict
-from typing import List
+from typing import List, Dict
 
 from django.conf import settings
 from datetime import datetime
@@ -36,13 +36,15 @@ class Event:
 class LinkedData:
     service: str = None
     origin_url: str = None
-    raw_data: dict = None
+    raw_data: Dict = None
 
+
+OntologyType = Dict[str, Dict[str, List[str]]]
 
 @dataclass
 class Root:
     event: Event
-    ontology: List[str] = field(default_factory=list)
+    ontology: OntologyType = None
     links: List[LinkedData] = field(default_factory=list)
     #suggest: List[str] = field(default_factory=list)
 

--- a/sources/ingest/fetch/keyword.py
+++ b/sources/ingest/fetch/keyword.py
@@ -1,0 +1,51 @@
+from .traffic import request_json
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+class Keyword:
+    """ Helper class for dealing with (yso) keyword ID's.
+        Instead of fething extra information for each ID separately, get
+        local cache and use it to enrich given ID's.
+    """
+
+    def __init__(self):
+        self.keywords = self._get_keywords()
+
+    def _get_keywords(self):
+        url = "https://api.hel.fi/linkedevents/v1/keyword/"
+        keywords = {}
+        total_count = 0
+
+        logger.debug(f"Fetching {url}")
+
+        while url:
+            data = request_json(url)
+            total_count += len(data["data"])
+
+            for elem in data["data"]:
+                keywords[elem["id"]] = elem
+
+            url = data["meta"]["next"]
+
+        logger.debug(f"Cached {total_count} keywords")
+        return keywords
+
+    def enrich_id(self, keyword_id):
+        if keyword_id in self.keywords:
+            return self.keywords[keyword_id]
+        return None
+
+    def enrich(self, keyword_list):
+        results = []
+
+        for elem in keyword_list:
+            # Format is as follows:
+            # {'@id': 'https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/keyword/yso:p1235/'}
+
+            _id = elem["@id"].split('/')[-2]
+            results.append(self.enrich_id(_id))
+
+        return results


### PR DESCRIPTION
Harvester
- Cache Linkedevents keywords locally.
- Store enriched keyword information in raw data.
- Store keywords grouped by language in new high level data structure "ontology". This
is supposed to be general purpose format to be shared between indexes.

GraphQL
- Use ontology fields in query. Event index now uses the general purpose format.