### PR TITLE
Cron improvements

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -110,16 +110,30 @@ jobs:
     name: Deploy cronjob
 
     steps:
-      - name: Deploy Cronjob
+      - name: Harvest location index
         uses: City-of-Helsinki/setup-cronjob-action@main
         with:
-          name: harvester
+          name: harvest-location
           image_repository: ghcr.io/city-of-helsinki/${{ github.event.repository.name }}/sources
           image_tag:  ${{ github.sha }}
           secret_name: project-sources-secret
           kubeconfig_raw: ${{ env.KUBECONFIG_RAW}}
           target_namespace: ${{ secrets.K8S_NAMESPACE_STABLE }}
-          schedule: '0 5 * * *' # at 05:00 every day
+          schedule: '0 3 * * *' # at 03:00 every day
           max_duration: "7200" # Run maximum 2 hours
           command: "{/bin/sh}"
-          args: "{-c,python manage.py ingest_data --index event location --delete && python manage.py ingest_data --index event location}"
+          args: "{-c,python manage.py ingest_data --index location --delete && python manage.py ingest_data --index location}"
+
+      - name: Harvest event index
+        uses: City-of-Helsinki/setup-cronjob-action@main
+        with:
+          name: harvest-event
+          image_repository: ghcr.io/city-of-helsinki/${{ github.event.repository.name }}/sources
+          image_tag:  ${{ github.sha }}
+          secret_name: project-sources-secret
+          kubeconfig_raw: ${{ env.KUBECONFIG_RAW}}
+          target_namespace: ${{ secrets.K8S_NAMESPACE_STABLE }}
+          schedule: '0 0 * * *' # at 00:00 every day
+          max_duration: "7200" # Run maximum 2 hours
+          command: "{/bin/sh}"
+          args: "{-c,python manage.py ingest_data --index event --delete && python manage.py ingest_data --index event}"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -111,16 +111,30 @@ jobs:
     name: Deploy cronjob
 
     steps:
-      - name: Deploy Cronjob
+      - name: Harvest location index
         uses: City-of-Helsinki/setup-cronjob-action@main
         with:
-          name: harvester
+          name: harvest-location
           image_repository: ghcr.io/city-of-helsinki/${{ github.event.repository.name }}/sources
           image_tag:  ${{ github.sha }}
           secret_name: project-staging-sources-secret
           kubeconfig_raw: ${{ env.KUBECONFIG_RAW}}
           target_namespace: ${{ secrets.K8S_NAMESPACE_STAGING }}
-          schedule: '0 3 * * *' # at 03:00 every day
+          schedule: '0 4 * * *' # at 04:00 every day
           max_duration: "7200" # Run maximum 2 hours
           command: "{/bin/sh}"
-          args: "{-c,python manage.py ingest_data --index event location --delete && python manage.py ingest_data --index event location}"
+          args: "{-c,python manage.py ingest_data --index location --delete && python manage.py ingest_data --index location}"
+
+      - name: Harvest event index
+        uses: City-of-Helsinki/setup-cronjob-action@main
+        with:
+          name: harvest-event
+          image_repository: ghcr.io/city-of-helsinki/${{ github.event.repository.name }}/sources
+          image_tag:  ${{ github.sha }}
+          secret_name: project-staging-sources-secret
+          kubeconfig_raw: ${{ env.KUBECONFIG_RAW}}
+          target_namespace: ${{ secrets.K8S_NAMESPACE_STAGING }}
+          schedule: '0 1 * * *' # at 01:00 every day
+          max_duration: "7200" # Run maximum 2 hours
+          command: "{/bin/sh}"
+          args: "{-c,python manage.py ingest_data --index event --delete && python manage.py ingest_data --index event}"

--- a/graphql/src/schemas/actor.ts
+++ b/graphql/src/schemas/actor.ts
@@ -50,6 +50,8 @@ export const actorSchema = `
   }
   """TODO: give real structure"""
   type Address {
-    streetAddress: String!
+    postalCode: String
+    streetAddress: LanguageString
+    city: LanguageString
   }
 `;

--- a/graphql/src/schemas/location.ts
+++ b/graphql/src/schemas/location.ts
@@ -27,7 +27,7 @@ export const locationSchema = `
   type LocationDescription {
     url: LanguageString
     geoLocation: GeoJSONFeature
-    streetAddress: Address
+    address: Address
     explanation: String
 	@origin(service: "linked", type: "event", attr: "location_extra_info")
     venue: Venue

--- a/sources/ingest/fetch/location.py
+++ b/sources/ingest/fetch/location.py
@@ -362,8 +362,8 @@ def fetch():
 
             root = Root(venue=venue)
             root.links.append(place_link)
-        except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError):
-            logger.warning(f"Error when fetching {place_url}")
+        except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError) as exc:
+            logger.warning(f"Error while fetching {place_url}: {exc}")
             pass
 
         # Extra information to raw data

--- a/sources/ingest/fetch/location.py
+++ b/sources/ingest/fetch/location.py
@@ -4,6 +4,7 @@ from typing import List
 from django.utils import timezone
 from django.conf import settings
 
+import requests
 import logging
 import base64
 import functools
@@ -351,15 +352,19 @@ def fetch():
             openingHours=opening_hours,
             images=images)
 
-        place_url, place = get_linkedevents_place(_id)
+        try:
+            place_url, place = get_linkedevents_place(_id)
 
-        place_link = LinkedData(
-            service="linkedevents",
-            origin_url=place_url,
-            raw_data=place)
+            place_link = LinkedData(
+                service="linkedevents",
+                origin_url=place_url,
+                raw_data=place)
 
-        root = Root(venue=venue)
-        root.links.append(place_link)
+            root = Root(venue=venue)
+            root.links.append(place_link)
+        except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError):
+            logger.warning(f"Error when fetching {place_url}")
+            pass
 
         # Extra information to raw data
         tpr_unit["origin"] = "tpr"

--- a/sources/ingest/fetch/location.py
+++ b/sources/ingest/fetch/location.py
@@ -36,8 +36,8 @@ class LinkedData:
 
 @dataclass
 class Address:
-    postal_code: str
-    street_address: LanguageString
+    postalCode: str
+    streetAddress: LanguageString
     city: LanguageString
 
 @dataclass
@@ -318,8 +318,8 @@ def fetch():
         location = Location(
             url=l.get_language_string("www"),
             address = Address(
-                postal_code=e("address_zip"),
-                street_address=l.get_language_string("street_address"),
+                postalCode=e("address_zip"),
+                streetAddress=l.get_language_string("street_address"),
                 city=l.get_language_string("address_city")
                 ),
             geoLocation=GeoJSONFeature(

--- a/sources/ingest/fetch/location.py
+++ b/sources/ingest/fetch/location.py
@@ -364,7 +364,6 @@ def fetch():
             root.links.append(place_link)
         except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError) as exc:
             logger.warning(f"Error while fetching {place_url}: {exc}")
-            pass
 
         # Extra information to raw data
         tpr_unit["origin"] = "tpr"


### PR DESCRIPTION
- Split harvester cron job into index specific jobs, "location" and "event".
- Fix address resolving. Variable names must match exactly on Python and TS side.
- Allow HTTP errors when storing Linkedevents place. In some cases the place is not available or there's NW error. Just skip and continue processing other units.