### PR TITLE
Fetch data with default page size

### DIFF
--- a/sources/ingest/fetch/event.py
+++ b/sources/ingest/fetch/event.py
@@ -52,7 +52,6 @@ class Root:
 def fetch():
     url = settings.EVENT_URL
 
-    payload = {"page_size": 100}
     received_count = 0
     try:
         es = Elasticsearch([settings.ES_URI])
@@ -64,7 +63,8 @@ def fetch():
     keyword = Keyword()
 
     while url:
-        r = requests.get(url, params=payload)
+        logger.debug(f"Requesting URL {url}")
+        r = requests.get(url)
         data = r.json()
         item_count = len(data["data"])
         received_count = received_count + item_count


### PR DESCRIPTION
This also prevents extra query strings in the URL as
meta.next returns query string back and it was then
duplicated in the URL.