### PR TITLE
Fetch only current events

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -21,7 +21,6 @@ env:
   K8S_LIMIT_RAM: 300Mi
   DEBUG: 1
   PLAYGROUND: 1
-  EVENT_URL: https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/event/
 
 jobs:
   build:
@@ -88,10 +87,8 @@ jobs:
         if: matrix.service == 'sources'
         env:
           SECRET_KEY: ${{ secrets.K8S_SECRET_SECRET_KEY_STAGING }}
-          EVENT_URL: ${{ env.EVENT_URL }}
         run: |
           echo "K8S_SECRET_SECRET_KEY=$SECRET_KEY" >> $GITHUB_ENV
-          echo "K8S_SECRET_EVENT_URL=$EVENT_URL" >> $GITHUB_ENV
 
       - name: Deploy ${{ matrix.service }}
         uses: andersinno/kolga-deploy-action@v2

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -24,7 +24,6 @@ env:
   K8S_LIMIT_RAM: 300Mi
   DEBUG: 0
   PLAYGROUND: 1
-  EVENT_URL: https://linkedevents-api.dev.hel.ninja/linkedevents-dev/v1/event/
 
 jobs:
   build:
@@ -91,10 +90,8 @@ jobs:
         if: matrix.service == 'sources'
         env:
           SECRET_KEY: ${{ secrets.K8S_SECRET_SECRET_KEY_STAGING }}
-          EVENT_URL: ${{ env.EVENT_URL }}
         run: |
           echo "K8S_SECRET_SECRET_KEY=$SECRET_KEY" >> $GITHUB_ENV
-          echo "K8S_SECRET_EVENT_URL=$EVENT_URL" >> $GITHUB_ENV
 
       - name: Deploy ${{ matrix.service }}
         uses: andersinno/kolga-deploy-action@v2

--- a/sources/sources/settings.py
+++ b/sources/sources/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 ES_URI = os.getenv("ES_URI")
 
 # Allow custom URL for testing purposes e.g. to match dev version of Linkedevents
-EVENT_URL = os.getenv("EVENT_URL", "https://api.hel.fi/linkedevents/v1/event/")
+EVENT_URL = os.getenv("EVENT_URL", "https://api.hel.fi/linkedevents/v1/event/?start=today")
 
 DEBUG = os.getenv("DEBUG", "false").lower() in ("yes", "true", "t", "1")
 


### PR DESCRIPTION
Greatly reduce the amount of events fetched. Remove custom Linkedevents URL used for staging event index.