### PR TITLE
Fix incorrect cursors after first page

### DIFF
--- a/graphql/src/datasources/es.ts
+++ b/graphql/src/datasources/es.ts
@@ -1,5 +1,4 @@
-import { ConnectionArguments, ElasticLanguage } from '../types';
-import { getEsOffsetPaginationQuery, targetFieldLanguages } from '../utils';
+import { ElasticLanguage } from '../types';
 
 const { RESTDataSource } = require('apollo-datasource-rest');
 
@@ -16,7 +15,8 @@ class ElasticSearchAPI extends RESTDataSource {
     q?: string,
     ontology?: string,
     index?: string,
-    connectionArguments?: ConnectionArguments,
+    from?: number,
+    size?: number,
     languages?: ElasticLanguage[]
   ) {
     const es_index = index ? index : this.defaultIndex;
@@ -108,7 +108,8 @@ class ElasticSearchAPI extends RESTDataSource {
 
     // Resolve pagination
     query = {
-      ...getEsOffsetPaginationQuery(connectionArguments),
+      from,
+      size,
       ...query,
     };
 


### PR DESCRIPTION
Previously cursors were generated naive of the current offset. This meant that nth cursors on two pages would be identical. For instance, the 2nd cursor would always point to the second result in the result set instead of the second result on a given page.

Now pagination takes pagination offset into account.

https://unified-search-fix-pagination-30-graphql.test.kuva.hel.ninja/search

Query that can be used for testing

```
query {
  unifiedSearch(
    q: "*"
    index: "location"
    ontology: "Liikunta"
    first: 4
  ) {
    count
    pageInfo {
      hasNextPage
      endCursor
    }
    edges {
      node {
        venue {
          name {
            fi
          }
        }
      }
    }
  }
}
```