### PR TITLE
US-47 | Add administrative divisions

### DIFF
--- a/graphql/src/datasources/es.ts
+++ b/graphql/src/datasources/es.ts
@@ -3,6 +3,7 @@ import { ElasticLanguage } from '../types';
 const { RESTDataSource } = require('apollo-datasource-rest');
 
 const ELASTIC_SEARCH_URI: string = process.env.ES_URI;
+const ES_ADMINISTRATIVE_DIVISION_INDEX = 'administrative_division';
 
 class ElasticSearchAPI extends RESTDataSource {
   constructor() {
@@ -14,7 +15,7 @@ class ElasticSearchAPI extends RESTDataSource {
   async getQueryResults(
     q?: string,
     ontology?: string,
-    administrativeDivision?: string,
+    administrativeDivisionId?: string,
     index?: string,
     from?: number,
     size?: number,
@@ -108,11 +109,11 @@ class ElasticSearchAPI extends RESTDataSource {
     }
 
     // Resolve administrative division
-    if (administrativeDivision) {
+    if (administrativeDivisionId) {
       query.query.bool.minimum_should_match = 1;
       query.query.bool.filter = {
         term: {
-          'venue.location.administrativeDivisions.id.keyword': administrativeDivision,
+          'venue.location.administrativeDivisions.id.keyword': administrativeDivisionId,
         },
       };
     }
@@ -155,6 +156,15 @@ class ElasticSearchAPI extends RESTDataSource {
     };
 
     return this.post(`${index}/_search`, undefined, {
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(query),
+    });
+  }
+
+  async getAdministrativeDivisions() {
+    const query = {"query": {"match_all": {}}};
+
+    return this.post(`${ES_ADMINISTRATIVE_DIVISION_INDEX}/_search`, undefined, {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(query),
     });

--- a/graphql/src/datasources/es.ts
+++ b/graphql/src/datasources/es.ts
@@ -14,6 +14,7 @@ class ElasticSearchAPI extends RESTDataSource {
   async getQueryResults(
     q?: string,
     ontology?: string,
+    administrativeDivision?: string,
     index?: string,
     from?: number,
     size?: number,
@@ -102,6 +103,16 @@ class ElasticSearchAPI extends RESTDataSource {
               },
             })),
           },
+        },
+      };
+    }
+
+    // Resolve administrative division
+    if (administrativeDivision) {
+      query.query.bool.minimum_should_match = 1;
+      query.query.bool.filter = {
+        term: {
+          'venue.location.administrativeDivisions.id.keyword': administrativeDivision,
         },
       };
     }

--- a/graphql/src/datasources/es.ts
+++ b/graphql/src/datasources/es.ts
@@ -29,13 +29,9 @@ class ElasticSearchAPI extends RESTDataSource {
           `venue.name.${lang}`,
           `venue.description.${lang}`,
           `links.raw_data.short_desc_${lang}`,
-        ]
-      }
-      else if (index === 'event') {
-        return [
-          `event.name.${lang}`,
-          `event.description.${lang}`,
-        ]
+        ];
+      } else if (index === 'event') {
+        return [`event.name.${lang}`, `event.description.${lang}`];
       }
       return [];
     };
@@ -47,16 +43,12 @@ class ElasticSearchAPI extends RESTDataSource {
           `links.raw_data.ontologyword_ids_enriched.ontologyword_${lang}`,
           `links.raw_data.ontologytree_ids_enriched.name_${lang}`,
           `links.raw_data.ontologytree_ids_enriched.extra_searchwords_${lang}`,
-        ]
-      }
-      else if (index === 'event') {
-        return [
-          `ontology.${lang}`,
-          `ontology.alt`,
-        ]
+        ];
+      } else if (index === 'event') {
+        return [`ontology.${lang}`, `ontology.alt`];
       }
       return [];
-    }
+    };
 
     const defaultQuery = languages.reduce(
       (acc, language) => ({
@@ -162,7 +154,7 @@ class ElasticSearchAPI extends RESTDataSource {
   }
 
   async getAdministrativeDivisions() {
-    const query = {"query": {"match_all": {}}};
+    const query = { query: { match_all: {} } };
 
     return this.post(`${ES_ADMINISTRATIVE_DIVISION_INDEX}/_search`, undefined, {
       headers: { 'Content-Type': 'application/json' },

--- a/graphql/src/index.ts
+++ b/graphql/src/index.ts
@@ -29,7 +29,7 @@ const SERVER_IS_NOT_READY = 'SERVER_IS_NOT_READY';
 type UnifiedSearchQuery = {
   q?: String;
   ontology?: string;
-  administrativeDivision?: string;
+  administrativeDivisionId?: string;
   index?: string;
   languages?: string[];
 } & ConnectionArguments;
@@ -61,7 +61,7 @@ const resolvers = {
       {
         q,
         ontology,
-        administrativeDivision,
+        administrativeDivisionId,
         index,
         before,
         after,
@@ -77,7 +77,7 @@ const resolvers = {
       const result = await dataSources.elasticSearchAPI.getQueryResults(
         q,
         ontology,
-        administrativeDivision,
+        administrativeDivisionId,
         index,
         from,
         size,
@@ -112,6 +112,13 @@ const resolvers = {
           label: option.text,
         })),
       };
+    },
+    administrativeDivisions: async (_, __, { dataSources }: any) => {
+      const res = await dataSources.elasticSearchAPI.getAdministrativeDivisions();
+      return res.hits.hits.map((hit: any) => ({
+        id: hit._id,
+        ...hit._source,
+      }));
     },
   },
   SearchResultConnection: {

--- a/graphql/src/index.ts
+++ b/graphql/src/index.ts
@@ -29,6 +29,7 @@ const SERVER_IS_NOT_READY = 'SERVER_IS_NOT_READY';
 type UnifiedSearchQuery = {
   q?: String;
   ontology?: string;
+  administrativeDivision?: string;
   index?: string;
   languages?: string[];
 } & ConnectionArguments;
@@ -60,6 +61,7 @@ const resolvers = {
       {
         q,
         ontology,
+        administrativeDivision,
         index,
         before,
         after,
@@ -75,6 +77,7 @@ const resolvers = {
       const result = await dataSources.elasticSearchAPI.getQueryResults(
         q,
         ontology,
+        administrativeDivision,
         index,
         from,
         size,

--- a/graphql/src/index.ts
+++ b/graphql/src/index.ts
@@ -36,7 +36,7 @@ type UnifiedSearchQuery = {
 
 function edgesFromEsResults(results: any, getCursor: any) {
   return results.hits.hits.map(function (
-    e: { _score: any; _source: { venue: any, event: any } },
+    e: { _score: any; _source: { venue: any; event: any } },
     index: number
   ) {
     return {
@@ -170,7 +170,6 @@ const resolvers = {
     meta({ event }: any, args: any, context: any, info: any) {
       return event.meta;
     },
-
   },
 
   RawJSON: {

--- a/graphql/src/schemas/location.ts
+++ b/graphql/src/schemas/location.ts
@@ -29,7 +29,8 @@ export const locationSchema = `
     geoLocation: GeoJSONFeature
     address: Address
     explanation: String
-	@origin(service: "linked", type: "event", attr: "location_extra_info")
+    @origin(service: "linked", type: "event", attr: "location_extra_info")
+    administrativeDivisions: [AdministrativeDivision]
     venue: Venue
   }
   """TODO: take this from service map / TPREK"""
@@ -53,4 +54,10 @@ export const locationSchema = `
     caption: LanguageString
   }
 
+  type AdministrativeDivision {
+    id: ID
+    type: String
+    municipality: String
+    name: LanguageString
+  }
 `;

--- a/graphql/src/schemas/query.ts
+++ b/graphql/src/schemas/query.ts
@@ -73,7 +73,7 @@ export const querySchema = `
         """
         Optional, filter to match only these administrative divisions
         """
-        administrativeDivision: ID,
+        administrativeDivisionId: ID,
 
         """
         Optional search index.
@@ -131,6 +131,8 @@ export const querySchema = `
       Optional result size.
       """
       size: Int = 5
-      ): SearchSuggestionConnection
+    ): SearchSuggestionConnection
+
+    administrativeDivisions: [AdministrativeDivision]
   }
 `;

--- a/graphql/src/schemas/query.ts
+++ b/graphql/src/schemas/query.ts
@@ -71,6 +71,11 @@ export const querySchema = `
         ontology: String,
 
         """
+        Optional, filter to match only these administrative divisions
+        """
+        administrativeDivision: ID,
+
+        """
         Optional search index.
         """
         index: String,

--- a/sources/ingest/fetch/location.py
+++ b/sources/ingest/fetch/location.py
@@ -58,6 +58,7 @@ class Location:
     url: LanguageString
     address: Address = None
     geoLocation: GeoJSONFeature = None
+    administrativeDivisions: List[AdministrativeDivision] = field(default_factory=list)
 
 
 @dataclass
@@ -77,6 +78,14 @@ class OntologyObject:
 class Image:
     url: str
     caption: LanguageString
+
+
+@dataclass
+class AdministrativeDivision:
+    id: str
+    type: str
+    municipality: str
+    name: LanguageString
 
 
 @dataclass
@@ -361,6 +370,10 @@ def fetch():
             place_link = LinkedData(
                 service="linkedevents", origin_url=place_url, raw_data=place
             )
+            venue.location.administrativeDivisions = [
+                AdministrativeDivision(id=le_division.pop("ocd_id"), **le_division)
+                for le_division in place["divisions"].copy()
+            ]
 
             root = Root(venue=venue)
             root.links.append(place_link)

--- a/sources/ingest/fetch/location.py
+++ b/sources/ingest/fetch/location.py
@@ -363,6 +363,7 @@ def fetch():
             openingHours=opening_hours,
             images=images,
         )
+        root = Root(venue=venue)
 
         try:
             place_url, place = get_linkedevents_place(_id)
@@ -375,7 +376,6 @@ def fetch():
                 for le_division in place["divisions"].copy()
             ]
 
-            root = Root(venue=venue)
             root.links.append(place_link)
         except (
             requests.exceptions.HTTPError,


### PR DESCRIPTION
Added administrative divisions:

* `Venues` now have field `location.administrativeDivisions` containing the venue's divisions
* It is possible to filter search results by a division by proving the division's ID in `admistrativeDivision` parameter
* Available divisions for filtering can fetched from the GraphQL API's by querying root level `administrativeDivisions`

Some considerations: 
* The GQL API includes only divisions that exist in the data. We might want to change that to include all of the divisions instead. 
* The list of all existing divisions is stored in its own ES index now, mainly just because that seemed to be the easiest option currently. We might want to change that, maybe even use something else than ES.