### PR TITLE
Add ontology tree id filter

### DIFF
--- a/graphql/src/datasources/es.ts
+++ b/graphql/src/datasources/es.ts
@@ -16,6 +16,7 @@ class ElasticSearchAPI extends RESTDataSource {
     q?: string,
     ontology?: string,
     administrativeDivisionId?: string,
+    ontologyTreeId?: string,
     index?: string,
     from?: number,
     size?: number,
@@ -100,14 +101,20 @@ class ElasticSearchAPI extends RESTDataSource {
       };
     }
 
-    // Resolve administrative division
+    let filters: { [key: string]: string }[] = [];
     if (administrativeDivisionId) {
+      filters.push({
+        'venue.location.administrativeDivisions.id.keyword': administrativeDivisionId,
+      });
+    }
+    if (ontologyTreeId) {
+      filters.push({
+        'links.raw_data.ontologytree_ids_enriched.id': ontologyTreeId,
+      });
+    }
+    if (filters.length) {
       query.query.bool.minimum_should_match = 1;
-      query.query.bool.filter = {
-        term: {
-          'venue.location.administrativeDivisions.id.keyword': administrativeDivisionId,
-        },
-      };
+      query.query.bool.filter = filters.map((filter) => ({ term: filter }));
     }
 
     // Resolve pagination

--- a/graphql/src/index.ts
+++ b/graphql/src/index.ts
@@ -30,6 +30,7 @@ type UnifiedSearchQuery = {
   q?: String;
   ontology?: string;
   administrativeDivisionId?: string;
+  ontologyTreeId?: string;
   index?: string;
   languages?: string[];
 } & ConnectionArguments;
@@ -62,6 +63,7 @@ const resolvers = {
         q,
         ontology,
         administrativeDivisionId,
+        ontologyTreeId,
         index,
         before,
         after,
@@ -78,6 +80,7 @@ const resolvers = {
         q,
         ontology,
         administrativeDivisionId,
+        ontologyTreeId,
         index,
         from,
         size,

--- a/graphql/src/schemas/query.ts
+++ b/graphql/src/schemas/query.ts
@@ -76,6 +76,11 @@ export const querySchema = `
         administrativeDivisionId: ID,
 
         """
+        Optional, filter to match only these ontology tree ids
+        """
+        ontologyTreeId: ID,
+
+        """
         Optional search index.
         """
         index: String,


### PR DESCRIPTION
Also results linked to the given ontology tree's child tree objects are included.

Example query:

```graphql
query {
  unifiedSearch(q: "ranta", index: "location", ontologyTreeId: 551) {
    edges {
      node {
        venue {
          name {
            fi
          }
        }
      }
    }
  }
}
```