### PR TITLE
Fix coordinate resolving for tprek venues

### DIFF
--- a/graphql/src/index.ts
+++ b/graphql/src/index.ts
@@ -208,10 +208,22 @@ const resolvers = {
     },
   },
   GeoJSONPoint: {
-    coordinates(obj: any, context: any, info: any) {
-      return obj.coordinates?.latitude && obj.coordinates?.longitude
-        ? [obj.coordinates.longitude, obj.coordinates.latitude]
-        : null;
+    type() {
+      return 'Point';
+    },
+    coordinates(obj: any) {
+      const long = obj.coordinates?.longitude ?? obj.longitude;
+      const lat = obj.coordinates?.latitude ?? obj.latitude;
+
+      return long && lat ? [long, lat] : null;
+    },
+  },
+  GeoJSONFeature: {
+    type() {
+      return 'Point';
+    },
+    geometry(parent: any) {
+      return parent;
     },
   },
 };


### PR DESCRIPTION
Coordinates would resolve as `null` for some venues. This change implements a `GeoJSONFeature` resolver which bridges the gap so that the `GeoJSONPoint` resolver gets called when the user asks for coordinates.

I also added some hardcoded definitions for some required type fields.