### PR TITLE
US-51 | Fix administrative divisions query to return all

### DIFF
--- a/graphql/src/datasources/es.ts
+++ b/graphql/src/datasources/es.ts
@@ -161,11 +161,8 @@ class ElasticSearchAPI extends RESTDataSource {
   }
 
   async getAdministrativeDivisions() {
-    const query = { query: { match_all: {} } };
-
-    return this.post(`${ES_ADMINISTRATIVE_DIVISION_INDEX}/_search`, undefined, {
+    return this.get(`${ES_ADMINISTRATIVE_DIVISION_INDEX}/_search`, {size: 10000}, {
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(query),
     });
   }
 


### PR DESCRIPTION
Fixed administrative divisions query to return all the divisions. Also changed the request which fetches the divisions from Elastic Search from POST to GET, because it is simpler and there is no need for a POST request.