### PR TITLE
US-56 & US-57 | Allow filtering by multiple divisions and ontology trees

### DIFF
--- a/graphql/src/index.ts
+++ b/graphql/src/index.ts
@@ -31,7 +31,9 @@ type UnifiedSearchQuery = {
   q?: String;
   ontology?: string;
   administrativeDivisionId?: string;
+  administrativeDivisionIds?: string[];
   ontologyTreeId?: string;
+  ontologyTreeIds?: string[];
   index?: string;
   languages?: string[];
 } & ConnectionArguments;
@@ -72,7 +74,9 @@ const resolvers = {
         q,
         ontology,
         administrativeDivisionId,
+        administrativeDivisionIds,
         ontologyTreeId,
+        ontologyTreeIds,
         index,
         before,
         after,
@@ -89,7 +93,9 @@ const resolvers = {
         q,
         ontology,
         administrativeDivisionId,
+        administrativeDivisionIds,
         ontologyTreeId,
+        ontologyTreeIds,
         index,
         from,
         size,

--- a/graphql/src/schemas/query.ts
+++ b/graphql/src/schemas/query.ts
@@ -71,14 +71,24 @@ export const querySchema = `
         ontology: String,
 
         """
+        Optional, filter to match only this administrative division. DEPRECATED! use administrativeDivisionIds instead.
+        """
+        administrativeDivisionId: ID
+
+        """
         Optional, filter to match only these administrative divisions
         """
-        administrativeDivisionId: ID,
+        administrativeDivisionIds: [ID],
+
+        """
+        Optional, filter to match only this ontology tree id. DEPRECATED! use ontologyTreeIds instead.
+        """
+        ontologyTreeId: ID
 
         """
         Optional, filter to match only these ontology tree ids
         """
-        ontologyTreeId: ID,
+        ontologyTreeIds: [ID],
 
         """
         Optional search index.


### PR DESCRIPTION
Added filters `administrativeDivisionIds` and `ontologyTreeIds` which allow filtering search results by multiple values which are ORred.