### PR TITLE
US-66 | Add filtering based on ontology word ids

### DIFF
--- a/graphql/src/datasources/es.ts
+++ b/graphql/src/datasources/es.ts
@@ -62,7 +62,19 @@ type OntologyTreeFilter = {
   };
 };
 
-type SearchFilters = Array<AdministrativeDivisionFilter | OntologyTreeFilter>;
+type OntologyWordFilter = {
+  bool: {
+    should: Array<{
+      term: {
+        'links.raw_data.ontologyword_ids_enriched.id': string;
+      };
+    }>;
+  };
+};
+
+type SearchFilters = Array<
+  AdministrativeDivisionFilter | OntologyTreeFilter | OntologyWordFilter
+>;
 
 class ElasticSearchAPI extends RESTDataSource {
   constructor() {
@@ -78,6 +90,7 @@ class ElasticSearchAPI extends RESTDataSource {
     administrativeDivisionIds?: string[],
     ontologyTreeId?: string,
     ontologyTreeIds?: string[],
+    ontologyWordIds?: string[],
     index?: string,
     from?: number,
     size?: number,
@@ -192,6 +205,19 @@ class ElasticSearchAPI extends RESTDataSource {
                 should: ontologyIds.map((ontologyId) => ({
                   term: {
                     'links.raw_data.ontologytree_ids_enriched.id': ontologyId,
+                  },
+                })),
+              },
+            },
+          ]
+        : []),
+      ...((ontologyWordIds ?? []).length
+        ? [
+            {
+              bool: {
+                should: ontologyWordIds.map((ontologyWordId) => ({
+                  term: {
+                    'links.raw_data.ontologyword_ids_enriched.id': ontologyWordId,
                   },
                 })),
               },

--- a/graphql/src/index.ts
+++ b/graphql/src/index.ts
@@ -34,6 +34,7 @@ type UnifiedSearchQuery = {
   administrativeDivisionIds?: string[];
   ontologyTreeId?: string;
   ontologyTreeIds?: string[];
+  ontologyWordIds?: string[];
   index?: string;
   languages?: string[];
 } & ConnectionArguments;
@@ -77,6 +78,7 @@ const resolvers = {
         administrativeDivisionIds,
         ontologyTreeId,
         ontologyTreeIds,
+        ontologyWordIds,
         index,
         before,
         after,
@@ -96,6 +98,7 @@ const resolvers = {
         administrativeDivisionIds,
         ontologyTreeId,
         ontologyTreeIds,
+        ontologyWordIds,
         index,
         from,
         size,

--- a/graphql/src/schemas/query.ts
+++ b/graphql/src/schemas/query.ts
@@ -91,6 +91,11 @@ export const querySchema = `
         ontologyTreeIds: [ID],
 
         """
+        Optional, filter to match only these ontology word ids
+        """
+        ontologyWordIds: [ID],
+
+        """
         Optional search index.
         """
         index: String,


### PR DESCRIPTION
Adds the `ontologyWordIds` filter into the `unifiedSearch` query.

Ontologies are sourced from tprek and matched with the same logic as ontology tree ids.