### PR TITLE
US-61 & US-62 | Search query "open at" filter

### DIFF
--- a/graphql/package.json
+++ b/graphql/package.json
@@ -19,12 +19,14 @@
     }
   },
   "dependencies": {
+    "@types/luxon": "^2.0.4",
     "apollo-datasource-rest": "^0.10.0",
     "apollo-server": "^2.21.1",
     "apollo-server-express": "^2.22.2",
     "cors": "^2.8.5",
     "express": "^4.17.1",
-    "graphql": "^15.5.0"
+    "graphql": "^15.5.0",
+    "luxon": "^2.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.13.16",

--- a/graphql/src/index.ts
+++ b/graphql/src/index.ts
@@ -37,6 +37,7 @@ type UnifiedSearchQuery = {
   ontologyWordIds?: string[];
   index?: string;
   languages?: string[];
+  openAt?: string;
 } & ConnectionArguments;
 
 function edgesFromEsResults(results: any, getCursor: any) {
@@ -85,6 +86,7 @@ const resolvers = {
         first,
         last,
         languages,
+        openAt,
       }: UnifiedSearchQuery,
       { dataSources }: any
     ) => {
@@ -102,7 +104,8 @@ const resolvers = {
         index,
         from,
         size,
-        elasticLanguageFromGraphqlLanguage(languages)
+        elasticLanguageFromGraphqlLanguage(languages),
+        openAt
       );
 
       const getCursor = (offset: number) =>

--- a/graphql/src/schemas/location.ts
+++ b/graphql/src/schemas/location.ts
@@ -49,6 +49,7 @@ export const locationSchema = `
     url: String
     is_open_now_url: String
     today: [OpeningHoursTimes]
+    data: [OpeningHoursDay]
   }
 
   type Image {
@@ -66,6 +67,11 @@ export const locationSchema = `
   type OntologyWord {
     id: ID
     label: LanguageString
+  }
+
+  type OpeningHoursDay {
+    date: String
+    times: [OpeningHoursTimes]
   }
 
   type OpeningHoursTimes {

--- a/graphql/src/schemas/query.ts
+++ b/graphql/src/schemas/query.ts
@@ -129,6 +129,14 @@ export const querySchema = `
         """
         languages: [UnifiedSearchLanguage!]! = [FINNISH, SWEDISH, ENGLISH]
 
+        """
+        Return only venues that are open at the given moment. In addition to ISO 8601 datetimes, accepts values
+        conforming to Elastic Search date math (https://www.elastic.co/guide/en/elasticsearch/reference/7.x/common-options.html#date-math)
+        like "now+3h". When there is a datetime provided without a timezone offset, "Europe/Helsinki" will be assumed
+        as the time zone.
+        """
+        openAt: String
+
       ): SearchResultConnection
 
     unifiedSearchCompletionSuggestions(

--- a/sources/ingest/importers/location.py
+++ b/sources/ingest/importers/location.py
@@ -275,6 +275,13 @@ custom_mappings = {
             "properties": {
                 "name": {"properties": define_language_properties()},
                 "description": {"properties": define_language_properties()},
+                "openingHours": {
+                    "properties": {
+                        "openRanges": {
+                            "type": "date_range",
+                        }
+                    }
+                },
             }
         },
     }

--- a/sources/ingest/importers/utils/opening_hours.py
+++ b/sources/ingest/importers/utils/opening_hours.py
@@ -13,6 +13,7 @@ from .traffic import request_json
 DEFAULT_BATCH_SIZE = 100
 # TODO make configurable
 HAUKI_BASE_URL = "https://hauki.api.hel.fi/v1/"
+NUMBER_OF_DAYS_TO_FETCH = 7
 
 HAUKI_RESOURCE_URL = HAUKI_BASE_URL + "resource/tprek:{venue_id}/"
 HAUKI_OPENING_HOURS_URL = HAUKI_BASE_URL + "opening_hours/"
@@ -122,11 +123,11 @@ class HaukiOpeningHoursFetcher:
 
     def fetch(self, ids: Sequence[str]) -> RawHoursById:
         today = localdate()
-        tomorrow = today + timedelta(days=1)
+        end_date = today + timedelta(days=NUMBER_OF_DAYS_TO_FETCH)
         prefixed_ids = (f"tprek:{i}" for i in ids)
         params = {
             "start_date": today,
-            "end_date": tomorrow,
+            "end_date": end_date,
             "resource": ",".join(prefixed_ids),
         }
         url = f"{HAUKI_OPENING_HOURS_URL}?{urlencode(params)}"

--- a/sources/ingest/importers/utils/tests/snapshots/snap_test_opening_hours.py
+++ b/sources/ingest/importers/utils/tests/snapshots/snap_test_opening_hours.py
@@ -64,6 +64,74 @@ snapshots['test_opening_hours_fetcher_data link 4'] = {
                     'start_time': '09:00:00'
                 }
             ]
+        },
+        {
+            'date': '2021-09-03',
+            'times': [
+                {
+                    'description': '',
+                    'end_time': '11:00:00',
+                    'end_time_on_next_day': False,
+                    'full_day': False,
+                    'name': '',
+                    'periods': [
+                        1306
+                    ],
+                    'resource_state': 'closed',
+                    'start_time': '10:00:00'
+                }
+            ]
+        },
+        {
+            'date': '2021-09-04',
+            'times': [
+                {
+                    'description': '',
+                    'end_time': None,
+                    'end_time_on_next_day': False,
+                    'full_day': True,
+                    'name': '',
+                    'periods': [
+                        1306
+                    ],
+                    'resource_state': 'open',
+                    'start_time': None
+                }
+            ]
+        },
+        {
+            'date': '2021-09-05',
+            'times': [
+                {
+                    'description': '',
+                    'end_time': None,
+                    'end_time_on_next_day': False,
+                    'full_day': True,
+                    'name': '',
+                    'periods': [
+                        1306
+                    ],
+                    'resource_state': 'closed',
+                    'start_time': None
+                }
+            ]
+        },
+        {
+            'date': '2021-09-06',
+            'times': [
+                {
+                    'description': '',
+                    'end_time': '05:00:00',
+                    'end_time_on_next_day': True,
+                    'full_day': False,
+                    'name': '',
+                    'periods': [
+                        1306
+                    ],
+                    'resource_state': 'open',
+                    'start_time': '09:00:00'
+                }
+            ]
         }
     ],
     'service': 'hauki'
@@ -90,6 +158,12 @@ snapshots['test_opening_hours_fetcher_data opening_hours 1'] = {
         }
     ],
     'is_open_now_url': 'https://hauki.api.hel.fi/v1/resource/tprek:1/is_open_now/',
+    'openRanges': [
+        {
+            'gte': '2021-09-03T11:00:00+03:00',
+            'lt': '2021-09-03T18:00:00+03:00'
+        }
+    ],
     'url': 'https://hauki.api.hel.fi/v1/resource/tprek:1/opening_hours/'
 }
 
@@ -97,6 +171,8 @@ snapshots['test_opening_hours_fetcher_data opening_hours 2'] = {
     'data': [
     ],
     'is_open_now_url': 'https://hauki.api.hel.fi/v1/resource/tprek:2/is_open_now/',
+    'openRanges': [
+    ],
     'url': 'https://hauki.api.hel.fi/v1/resource/tprek:2/opening_hours/'
 }
 
@@ -104,6 +180,8 @@ snapshots['test_opening_hours_fetcher_data opening_hours 3'] = {
     'data': [
     ],
     'is_open_now_url': 'https://hauki.api.hel.fi/v1/resource/tprek:3/is_open_now/',
+    'openRanges': [
+    ],
     'url': 'https://hauki.api.hel.fi/v1/resource/tprek:3/opening_hours/'
 }
 
@@ -125,8 +203,94 @@ snapshots['test_opening_hours_fetcher_data opening_hours 4'] = {
                     'startTime': '09:00:00'
                 }
             ]
+        },
+        {
+            'date': '2021-09-03',
+            'times': [
+                {
+                    'description': '',
+                    'endTime': '11:00:00',
+                    'endTimeOnNextDay': False,
+                    'fullDay': False,
+                    'name': '',
+                    'periods': [
+                        1306
+                    ],
+                    'resourceState': 'closed',
+                    'startTime': '10:00:00'
+                }
+            ]
+        },
+        {
+            'date': '2021-09-04',
+            'times': [
+                {
+                    'description': '',
+                    'endTime': None,
+                    'endTimeOnNextDay': False,
+                    'fullDay': True,
+                    'name': '',
+                    'periods': [
+                        1306
+                    ],
+                    'resourceState': 'open',
+                    'startTime': None
+                }
+            ]
+        },
+        {
+            'date': '2021-09-05',
+            'times': [
+                {
+                    'description': '',
+                    'endTime': None,
+                    'endTimeOnNextDay': False,
+                    'fullDay': True,
+                    'name': '',
+                    'periods': [
+                        1306
+                    ],
+                    'resourceState': 'closed',
+                    'startTime': None
+                }
+            ]
+        },
+        {
+            'date': '2021-09-06',
+            'times': [
+                {
+                    'description': '',
+                    'endTime': '05:00:00',
+                    'endTimeOnNextDay': True,
+                    'fullDay': False,
+                    'name': '',
+                    'periods': [
+                        1306
+                    ],
+                    'resourceState': 'open',
+                    'startTime': '09:00:00'
+                }
+            ]
         }
     ],
     'is_open_now_url': 'https://hauki.api.hel.fi/v1/resource/tprek:4/is_open_now/',
+    'openRanges': [
+        {
+            'gte': '2021-09-03T09:00:00+03:00',
+            'lt': '2021-09-03T10:00:00+03:00'
+        },
+        {
+            'gte': '2021-09-03T11:00:00+03:00',
+            'lt': '2021-09-03T16:00:00+03:00'
+        },
+        {
+            'gte': '2021-09-04T00:00:00+03:00',
+            'lt': '2021-09-05T00:00:00+03:00'
+        },
+        {
+            'gte': '2021-09-06T09:00:00+03:00',
+            'lt': '2021-09-07T05:00:00+03:00'
+        }
+    ],
     'url': 'https://hauki.api.hel.fi/v1/resource/tprek:4/opening_hours/'
 }


### PR DESCRIPTION
Implemented search query `openAt` filter for venues, which limits the results to venues that are open at the given time.

The filter accepts ISO 8601 datetimes with and without a timezone offset (if there is no offset given, the datetime is assumed to be in timezone "Europe/Helsinki") and values conforming to Elastic Search date math, like "now+3h".

The make implementing the filter possible, all venues' open hours are indexed as ranges of datetimes when the venues are open. The ranges are built based on Hauki's `"resource_state"` `"open"` time ranges which are overridden by `"resource_state"` `"closed"` ranges.

This PR also includes a change that opening hours of the next 7 days are imported instead of the previous value of 1, and all of those opening hours are now exposed via the GraphQL API.
