### PR TITLE
Fix ingest cronjobs

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -122,7 +122,7 @@ jobs:
           schedule: '0 3 * * *' # at 03:00 every day
           max_duration: "21600" # Run maximum 6 hours
           command: "{/bin/sh}"
-          args: "{-c,python manage.py ingest_data location --delete && python manage.py ingest_data location}"
+          args: "{-c,python manage.py ingest_data location}"
 
       - name: Harvest event index
         uses: City-of-Helsinki/setup-cronjob-action@main
@@ -136,7 +136,7 @@ jobs:
           schedule: '0 0 * * *' # at 00:00 every day
           max_duration: "21600" # Run maximum 6 hours
           command: "{/bin/sh}"
-          args: "{-c,python manage.py ingest_data event --delete && python manage.py ingest_data event}"
+          args: "{-c,python manage.py ingest_data event}"
 
       - name: Harvest ontology tree index
         uses: City-of-Helsinki/setup-cronjob-action@main
@@ -150,4 +150,4 @@ jobs:
           schedule: '0 6 * * *' # at 06:00 every day
           max_duration: "21600" # Run maximum 6 hours
           command: "{/bin/sh}"
-          args: "{-c,python manage.py ingest_data ontology_tree --delete && python manage.py ingest_data ontology_tree}"
+          args: "{-c,python manage.py ingest_data ontology_tree}"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -122,7 +122,7 @@ jobs:
           schedule: '0 4 * * *' # at 04:00 every day
           max_duration: "21600" # Run maximum 6 hours
           command: "{/bin/sh}"
-          args: "{-c,python manage.py ingest_data location --delete && python manage.py ingest_data location}"
+          args: "{-c,python manage.py ingest_data location}"
 
       - name: Harvest event index
         uses: City-of-Helsinki/setup-cronjob-action@main
@@ -136,7 +136,7 @@ jobs:
           schedule: '0 1 * * *' # at 01:00 every day
           max_duration: "21600" # Run maximum 6 hours
           command: "{/bin/sh}"
-          args: "{-c,python manage.py ingest_data event --delete && python manage.py ingest_data event}"
+          args: "{-c,python manage.py ingest_data event}"
 
       - name: Harvest ontology tree index
         uses: City-of-Helsinki/setup-cronjob-action@main
@@ -150,4 +150,4 @@ jobs:
           schedule: '0 7 * * *' # at 07:00 every day
           max_duration: "21600" # Run maximum 6 hours
           command: "{/bin/sh}"
-          args: "{-c,python manage.py ingest_data ontology_tree --delete && python manage.py ingest_data ontology_tree}"
+          args: "{-c,python manage.py ingest_data ontology_tree}"


### PR DESCRIPTION
We have the new fancy double index and alias system to provide transactional ingest runs, we don't want no index deletion before ingesting data no more!