### PR TITLE
US-63 | Allow sorting search results by distance

### DIFF
--- a/graphql/src/datasources/es.ts
+++ b/graphql/src/datasources/es.ts
@@ -44,6 +44,12 @@ type OntologyTreeQueryBool = {
   };
 };
 
+export type OrderByDistanceParams = {
+  latitude: number;
+  longitude: number;
+  order: 'ASCENDING' | 'DESCENDING';
+};
+
 type OpenAtFilter = {
   term: {
     'venue.openingHours.openRanges': string;
@@ -105,7 +111,8 @@ class ElasticSearchAPI extends RESTDataSource {
     from?: number,
     size?: number,
     languages?: ElasticLanguage[],
-    openAt?: string
+    openAt?: string,
+    orderByDistance?: OrderByDistanceParams
   ) {
     const es_index = index ? index : this.defaultIndex;
 
@@ -230,6 +237,16 @@ class ElasticSearchAPI extends RESTDataSource {
     if (filters.length) {
       query.query.bool.minimum_should_match = 1;
       query.query.bool.filter = filters;
+    }
+
+    if (typeof orderByDistance !== 'undefined') {
+      query.sort = {
+        _geo_distance: {
+          location: [orderByDistance.latitude, orderByDistance.longitude],
+          order: orderByDistance.order === 'DESCENDING' ? 'desc' : 'asc',
+          ignore_unmapped: true,
+        },
+      };
     }
 
     // Resolve pagination

--- a/graphql/src/index.ts
+++ b/graphql/src/index.ts
@@ -9,6 +9,7 @@ import {
 } from './utils';
 import pageInfoResolver from './resolvers/pageInfoResolver';
 import { ConnectionArguments, ConnectionCursorObject } from './types';
+import { OrderByDistanceParams } from './datasources/es';
 
 const { elasticSearchSchema } = require('./schemas/es');
 const { palvelukarttaSchema } = require('./schemas/palvelukartta');
@@ -38,6 +39,7 @@ type UnifiedSearchQuery = {
   index?: string;
   languages?: string[];
   openAt?: string;
+  orderByDistance?: OrderByDistanceParams;
 } & ConnectionArguments;
 
 function edgesFromEsResults(results: any, getCursor: any) {
@@ -87,6 +89,7 @@ const resolvers = {
         last,
         languages,
         openAt,
+        orderByDistance,
       }: UnifiedSearchQuery,
       { dataSources }: any
     ) => {
@@ -105,7 +108,8 @@ const resolvers = {
         from,
         size,
         elasticLanguageFromGraphqlLanguage(languages),
-        openAt
+        openAt,
+        orderByDistance
       );
 
       const getCursor = (offset: number) =>
@@ -138,7 +142,8 @@ const resolvers = {
       };
     },
     administrativeDivisions: async (_, __, { dataSources }: any) => {
-      const res = await dataSources.elasticSearchAPI.getAdministrativeDivisions();
+      const res =
+        await dataSources.elasticSearchAPI.getAdministrativeDivisions();
       return res.hits.hits.map((hit: any) => ({
         id: hit._id,
         ...hit._source,

--- a/graphql/src/schemas/query.ts
+++ b/graphql/src/schemas/query.ts
@@ -58,6 +58,17 @@ export const querySchema = `
     suggestions: [Suggestion]!
   }
 
+  enum SortOrder {
+    ASCENDING
+    DESCENDING
+  }
+
+  input OrderByDistance {
+    latitude: Float
+    longitude: Float
+    order: SortOrder = ASCENDING
+  }
+
   type Query {
     unifiedSearch(
         """
@@ -136,6 +147,11 @@ export const querySchema = `
         as the time zone.
         """
         openAt: String
+
+        """
+        Order results by distance to given coordinates.
+        """
+        orderByDistance: OrderByDistance
 
       ): SearchResultConnection
 

--- a/sources/ingest/importers/location.py
+++ b/sources/ingest/importers/location.py
@@ -112,8 +112,15 @@ class Venue:
 
 
 @dataclass
+class GeoPoint:
+    latitude: float
+    longitude: float
+
+
+@dataclass
 class Root:
     venue: Venue
+    location: GeoPoint = None
     links: List[LinkedData] = field(default_factory=list)
     suggest: List[str] = field(default_factory=list)
 
@@ -284,6 +291,7 @@ custom_mappings = {
                 },
             }
         },
+        "location": {"type": "geo_point"},
     }
 }
 
@@ -420,6 +428,12 @@ class LocationImporter(Importer[Union[Root, AdministrativeDivision]]):
                 raw_data=tpr_unit,
             )
             root.links.append(link)
+
+            root.location = (
+                {"lat": e("latitude"), "lon": e("longitude")}
+                if e("latitude") and e("longitude")
+                else None
+            )
 
             self.add_data(root, self.LOCATION_INDEX)
 


### PR DESCRIPTION
Added argument

    orderByDistance: {latitude: Float, longitude: Float, order: SortOrder = ASCENDING}

to the search query, which allows sorting the results by their distance to the given point, by default nearest first.

Venues' coordinates are indexed as a separate `geo_point` to support this.

Example query:
```graphql
query {
  unifiedSearch(q: "uimahalli", index: "location", orderByDistance: {latitude: 24.937, longitude: 60.163}) {
    edges {
      node {
        venue {
          name {
            fi
          }
        }
      }
    }
  }
}
```
