### PR TITLE
US-64 |  Helsinki common administrative divisions

### DIFF
--- a/graphql/src/datasources/es.ts
+++ b/graphql/src/datasources/es.ts
@@ -5,6 +5,8 @@ const { RESTDataSource } = require('apollo-datasource-rest');
 
 const ELASTIC_SEARCH_URI: string = process.env.ES_URI;
 const ES_ADMINISTRATIVE_DIVISION_INDEX = 'administrative_division';
+const ES_HELSINKI_COMMON_ADMINISTRATIVE_DIVISION_INDEX =
+  'helsinki_common_administrative_division';
 const ES_ONTOLOGY_TREE_INDEX = 'ontology_tree';
 const DEFAULT_TIME_ZONE = 'Europe/Helsinki';
 
@@ -42,6 +44,10 @@ type OntologyTreeQueryBool = {
       field: 'childIds';
     };
   };
+};
+
+type AdministrativeDivisionParams = {
+  helsinkiCommonOnly?: boolean;
 };
 
 export type OrderByDistanceParams = {
@@ -295,9 +301,14 @@ class ElasticSearchAPI extends RESTDataSource {
     });
   }
 
-  async getAdministrativeDivisions() {
+  async getAdministrativeDivisions({
+    helsinkiCommonOnly,
+  }: AdministrativeDivisionParams) {
+    const index = helsinkiCommonOnly
+      ? ES_HELSINKI_COMMON_ADMINISTRATIVE_DIVISION_INDEX
+      : ES_ADMINISTRATIVE_DIVISION_INDEX;
     return this.get(
-      `${ES_ADMINISTRATIVE_DIVISION_INDEX}/_search`,
+      `${index}/_search`,
       { size: 10000 },
       {
         headers: { 'Content-Type': 'application/json' },

--- a/graphql/src/index.ts
+++ b/graphql/src/index.ts
@@ -141,9 +141,10 @@ const resolvers = {
         })),
       };
     },
-    administrativeDivisions: async (_, __, { dataSources }: any) => {
-      const res =
-        await dataSources.elasticSearchAPI.getAdministrativeDivisions();
+    administrativeDivisions: async (_, args, { dataSources }: any) => {
+      const res = await dataSources.elasticSearchAPI.getAdministrativeDivisions(
+        args
+      );
       return res.hits.hits.map((hit: any) => ({
         id: hit._id,
         ...hit._source,

--- a/graphql/src/schemas/query.ts
+++ b/graphql/src/schemas/query.ts
@@ -177,7 +177,12 @@ export const querySchema = `
       size: Int = 5
     ): SearchSuggestionConnection
 
-    administrativeDivisions: [AdministrativeDivision]
+    administrativeDivisions(
+        """
+        Return only Helsinki administrative divisions that make a sensible set to be used as an option list in an UI for example.
+        """
+        helsinkiCommonOnly: Boolean): [AdministrativeDivision]
+
     ontologyTree(
       rootId: ID
       leavesOnly: Boolean

--- a/sources/ingest/importers/location.py
+++ b/sources/ingest/importers/location.py
@@ -299,7 +299,14 @@ custom_mappings = {
 class LocationImporter(Importer[Union[Root, AdministrativeDivision]]):
     LOCATION_INDEX = "location"
     ADMINISTRATIVE_DIVISION_INDEX = "administrative_division"
-    index_base_names = (LOCATION_INDEX, ADMINISTRATIVE_DIVISION_INDEX)
+    HELSINKI_COMMON_ADMINISTRATIVE_DIVISION_INDEX = (
+        "helsinki_common_administrative_division"
+    )
+    index_base_names = (
+        LOCATION_INDEX,
+        ADMINISTRATIVE_DIVISION_INDEX,
+        HELSINKI_COMMON_ADMINISTRATIVE_DIVISION_INDEX,
+    )
 
     def run(self):  # noqa C901 this function could use some refactoring
         self.apply_mapping(custom_mappings, self.LOCATION_INDEX)
@@ -312,6 +319,7 @@ class LocationImporter(Importer[Union[Root, AdministrativeDivision]]):
 
         opening_hours_fetcher = HaukiOpeningHoursFetcher(t["id"] for t in tpr_units)
 
+        helsinki_neighborhoods = set()
         count = 0
         for tpr_unit in tpr_units:
             l = LanguageStringConverter(tpr_unit)
@@ -441,6 +449,31 @@ class LocationImporter(Importer[Union[Root, AdministrativeDivision]]):
             # that they can be easily returned from the GQL API. We might want to change
             # this implementation in the future, maybe even use something else than ES.
             for division in venue.location.administrativeDivisions:
+
+                # store a certain set of Helsinki's divisions into it's own index. This
+                # set is mostly meant to be used to provide division choices list for a
+                # UI. Whether this kind of set should be provided by US in the first
+                # place is a good question, and the answer might very well be no, so
+                # this is subject to change in the future.
+                #
+                # Currently includes all neighborhoods and sub districts with
+                # duplicates removed.
+                if (
+                    division.type in ("neighborhood", "sub_district")
+                    and division.municipality == "Helsinki"
+                ):
+                    if not (
+                        division.type == "sub_district"
+                        and division.name["fi"] in helsinki_neighborhoods
+                    ):
+                        self.add_data(
+                            division,
+                            self.HELSINKI_COMMON_ADMINISTRATIVE_DIVISION_INDEX,
+                            extra_params={"id": division.id},
+                        )
+                    if division.type == "neighborhood":
+                        helsinki_neighborhoods.add(division.name["fi"])
+
                 self.add_data(
                     division,
                     self.ADMINISTRATIVE_DIVISION_INDEX,


### PR DESCRIPTION
Created a set of Helsinki administrative divisions that can be used in a UI as division choices. They are put in their own index for easier usage. Added argument `helsinkiCommonOnly` which can be used to fetch those from the GraphQL API.

**NOTE**: There are many fuzzy factors about this thing, starting from the question that should this even be in Unified Search in the first place, so this implementation is subject to change in the future.

Example query:

```graphql
query {
  administrativeDivisions(helsinkiCommonOnly: true) {
    type
    name {
      fi
    }
  }
}
```
