### PR TITLE
US-69 | Allow ordering results by name

### DIFF
--- a/graphql/src/datasources/es.ts
+++ b/graphql/src/datasources/es.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon';
 import { ElasticLanguage } from '../types';
-import { ValidationError } from 'apollo-server-express';
+import isUndefined from 'lodash/isUndefined';
 
 const { RESTDataSource } = require('apollo-datasource-rest');
 
@@ -258,16 +258,8 @@ class ElasticSearchAPI extends RESTDataSource {
       query.query.bool.filter = filters;
     }
 
-    const hasDistanceOrdering = typeof orderByDistance !== 'undefined';
-    const hasNameOrdering = typeof orderByName !== 'undefined';
-
-    if (hasDistanceOrdering && hasNameOrdering) {
-      throw new ValidationError(
-        'Cannot use both orderByDistance and orderByName.'
-      );
-    }
     if (['event', 'location'].includes(es_index)) {
-      if (hasDistanceOrdering) {
+      if (!isUndefined(orderByDistance)) {
         query.sort = {
           _geo_distance: {
             location: {
@@ -278,7 +270,7 @@ class ElasticSearchAPI extends RESTDataSource {
             ignore_unmapped: true,
           },
         };
-      } else if (hasNameOrdering) {
+      } else if (!isUndefined(orderByName)) {
         const type = es_index === 'location' ? 'venue' : 'event';
         const language = languages[0] ?? 'fi';
         query.sort = {

--- a/graphql/src/schemas/query.ts
+++ b/graphql/src/schemas/query.ts
@@ -64,8 +64,8 @@ export const querySchema = `
   }
 
   input OrderByDistance {
-    latitude: Float
-    longitude: Float
+    latitude: Float!
+    longitude: Float!
     order: SortOrder = ASCENDING
   }
 


### PR DESCRIPTION
Implemented ability to order results by name with argument `orderByName: {order: SortOrder = ASCENDING}`. The language used is the first one given in `languages` argument (default Finnish). Works for both locations and events.

Example query:

```graphql
query {
  unifiedSearch(q: "*",  orderByName: {order: ASCENDING}) {
    edges {
      node {
        venue {
          name {
            fi
          }
        }
      }
    }
  }
}
```