### PR TITLE
Prevent stopped docker-compose containers restarting on boot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - "5000:5000"
     environment:
       APPLY_MIGRATIONS: 1
-    restart: always
+    restart: unless-stopped
     volumes:
       - ./sources:/app
     networks:
@@ -30,7 +30,7 @@ services:
       - /app/node_modules
     ports:
       - "4000:4000"
-    restart: always
+    restart: unless-stopped
     networks:
       - elastic
 


### PR DESCRIPTION
`unless-stopped` is similar to `always` flag, but it doesn't restart any stopped containers when the Docker daemon restarts (e.g. on system boot).

https://docs.docker.com/config/containers/start-containers-automatically/#use-a-restart-policy