### PR TITLE
Fixed the UnsupportedProductError

### DIFF
--- a/sources/ingest/apps.py
+++ b/sources/ingest/apps.py
@@ -3,3 +3,4 @@ from django.apps import AppConfig
 
 class IngestConfig(AppConfig):
     name = "ingest"
+    default_auto_field = "django.db.models.BigAutoField"

--- a/sources/requirements.in
+++ b/sources/requirements.in
@@ -1,6 +1,6 @@
 certifi
 Django
-elasticsearch
+elasticsearch<7.14.0
 requests
 pyhumps
 # TODO use PyPI version once available

--- a/sources/requirements.txt
+++ b/sources/requirements.txt
@@ -42,7 +42,7 @@ django-parler-rest==2.1
     # via django-munigeo
 djangorestframework==3.13.1
     # via django-parler-rest
-elasticsearch==7.16.2
+elasticsearch==7.13.4
     # via -r requirements.in
 idna==3.3
     # via requests

--- a/sources/sources/settings.py
+++ b/sources/sources/settings.py
@@ -170,3 +170,5 @@ LOGGING = {
         },
     },
 }
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"


### PR DESCRIPTION
US-87. Downgraded the elasticsearch library to fix the server is not a supported distribution of Elasticsearch -error: https://towardsaws.com/elasticsearch-the-server-is-not-a-supported-distribution-of-elasticsearch-252abc1bd92. Also set the default AutoField setting, because current version of munigeo does not set it.