### PR TITLE
Use a default page size value with the hasNextPage when a first argument is not given

### DIFF
--- a/graphql/src/datasources/es.ts
+++ b/graphql/src/datasources/es.ts
@@ -11,6 +11,9 @@ const ES_HELSINKI_COMMON_ADMINISTRATIVE_DIVISION_INDEX =
 const ES_ONTOLOGY_TREE_INDEX = 'ontology_tree';
 const ES_ONTOLOGY_WORD_INDEX = 'ontology_word';
 const DEFAULT_TIME_ZONE = 'Europe/Helsinki';
+// The default page size when the first or last arguments are not given.
+// This is the default page size set by OpenSearch / ElasticSearch
+const ES_DEFAULT_PAGE_SIZE = 10;
 
 type OntologyTreeParams = {
   rootId?: string;
@@ -141,9 +144,7 @@ class ElasticSearchAPI extends RESTDataSource {
       1: (lang: string, index: string) => {
         return (
           {
-            location: [
-              `venue.description.${lang}`,
-            ],
+            location: [`venue.description.${lang}`],
             event: [`event.name.${lang}`, `event.description.${lang}`],
           }[index] ?? []
         );
@@ -410,4 +411,4 @@ class ElasticSearchAPI extends RESTDataSource {
   }
 }
 
-export { ElasticSearchAPI };
+export { ElasticSearchAPI, ES_DEFAULT_PAGE_SIZE };

--- a/graphql/src/resolvers/pageInfoResolver.ts
+++ b/graphql/src/resolvers/pageInfoResolver.ts
@@ -1,3 +1,4 @@
+import { ES_DEFAULT_PAGE_SIZE } from '../datasources/es';
 import { SupportedConnectionArguments, ConnectionCursorObject } from '../types';
 import { readCursor } from '../utils';
 
@@ -25,7 +26,8 @@ export async function pageInfoResolver(
   const pageStart =
     readCursor<ConnectionCursorObject | null>(connectionArguments.after)
       ?.offset ?? 0;
-  const pageLength = connectionArguments.first;
+  // TODO: pageLength could support the last -argument, but it's an excluded in SupportedConnectionArguments.
+  const pageLength = connectionArguments.first ?? ES_DEFAULT_PAGE_SIZE;
 
   return {
     hasNextPage: pageStart + pageLength < totalHits,


### PR DESCRIPTION
US-83. Before the fix, hasNextPage was always `false`, if the first -argument was not given.

Test query:
```
{
  unifiedSearch(
    q: "*"
  ) {
    count
    pageInfo {
      hasNextPage
      hasPreviousPage
    }
    edges {
      node {
        venue {
          name {
            fi
          }
        }
      }
    }
  }
}
```