### PR TITLE
Added text and defaultLanguage fields to LanguageString

### DIFF
--- a/sources/ingest/importers/utils/shared.py
+++ b/sources/ingest/importers/utils/shared.py
@@ -7,6 +7,14 @@ class LanguageString:
     fi: str = None
     sv: str = None
     en: str = None
+    text: str = None
+    defaultLanguage: str = "FI"
+
+    def __init__(self, **kwargs):
+        self.fi = kwargs["fi"]
+        self.sv = kwargs["sv"]
+        self.en = kwargs["en"]
+        self.text = kwargs[self.defaultLanguage.lower()]
 
 
 @dataclass

--- a/sources/ingest/tests/test_language.py
+++ b/sources/ingest/tests/test_language.py
@@ -62,3 +62,13 @@ class LanguageTestCase(TestCase):
         )
         self.assertEqual(l.get_language_string("baz"), None)
         self.assertEqual(l.get_language_string("foz"), None)
+
+    def test_language_string_text(self):
+        input = {"foo_fi": "kissa", "bar_fi": "koira"}
+        l = LanguageStringConverter(input)
+        assert l.get_language_string("foo").text == input["foo_fi"]
+
+    def test_language_string_default_language(self):
+        input = {"foo_fi": "kissa", "bar_fi": "koira"}
+        l = LanguageStringConverter(input)
+        assert l.get_language_string("foo").defaultLanguage == "FI"


### PR DESCRIPTION
US-48 US-94.

The fix is done in a data importer, so to test and apply the changes, the ingest_data -script needs to be ran: `python manage.py ingest_data`