### PR TITLE
Upgrade the Apollo server related dependencies and migrate the monolith graph to a new subgraph

### DIFF
--- a/graphql/Dockerfile
+++ b/graphql/Dockerfile
@@ -1,5 +1,5 @@
 # ===============================================
-FROM helsinkitest/node:12-slim as appbase
+FROM helsinkitest/node:16-slim as appbase
 # ===============================================
 
 # Offical image has npm log verbosity as info. More info - https://github.com/nodejs/docker-node#verbosity

--- a/graphql/package.json
+++ b/graphql/package.json
@@ -19,16 +19,19 @@
     }
   },
   "dependencies": {
-    "@graphql-tools/schema": "^8.3.1",
+    "@apollo/subgraph": "^2.1.4",
+    "@graphql-tools/schema": "^9.0.9",
     "@sentry/node": "^6.16.1",
     "@types/luxon": "^2.0.9",
-    "apollo-datasource-rest": "^3.5.0",
-    "apollo-server": "^3.3.0",
-    "apollo-server-express": "^3.6.1",
-    "apollo-server-plugin-response-cache": "^3.5.0",
+    "@types/node": "^18.11.9",
+    "apollo-datasource-rest": "^3.7.0",
+    "apollo-server": "^3.11.1",
+    "apollo-server-express": "^3.11.1",
+    "apollo-server-plugin-response-cache": "^3.8.1",
     "cors": "^2.8.5",
     "express": "^4.17.2",
-    "graphql": "^15.5.0",
+    "graphql": "^16.6.0",
+    "graphql-tag": "^2.12.6",
     "luxon": "^2.3.0"
   },
   "devDependencies": {
@@ -39,8 +42,8 @@
     "babel-jest": "^26.6.3",
     "nodemon": "^2.0.15",
     "prettier": "^2.5.1",
-    "ts-jest": "^26.5.5",
+    "ts-jest": "^29.0.3",
     "ts-node": "^8.3.0",
-    "typescript": "^3.5.3"
+    "typescript": "^4.8.4"
   }
 }

--- a/graphql/src/index.ts
+++ b/graphql/src/index.ts
@@ -1,5 +1,5 @@
 const { ApolloServer } = require('apollo-server-express');
-import { makeExecutableSchema } from '@graphql-tools/schema';
+import { buildSubgraphSchema } from '@apollo/subgraph';
 import {
   ApolloServerPluginLandingPageGraphQLPlayground,
   ApolloServerPluginLandingPageDisabled,
@@ -317,14 +317,14 @@ const resolvers = {
   },
 };
 
-const combinedSchema = makeExecutableSchema({
+const combinedSchema = buildSubgraphSchema({
   typeDefs: [
     querySchema,
     elasticSearchSchema,
     palvelukarttaSchema,
     linkedeventsSchema,
     locationSchema,
-    sharedSchema,
+    sharedSchema, // FIXME: OVerlapping with events-proxy (https://tapahtumat-proxy.test.kuva.hel.ninja/proxy/graphql); Keyword and Location Image
     reservationSchema,
     eventSchema,
     actorSchema,
@@ -377,14 +377,10 @@ const sentryConfig = {
         elasticSearchAPI: new ElasticSearchAPI(),
       };
     },
+    playground:
+      process.env.PLAYGROUND !== null ? Boolean(process.env.PLAYGROUND) : true,
     introspection: true,
-    plugins: [
-      process.env.PLAYGROUND
-        ? ApolloServerPluginLandingPageGraphQLPlayground()
-        : ApolloServerPluginLandingPageDisabled(),
-      responseCachePlugin(),
-      sentryConfig,
-    ],
+    plugins: [responseCachePlugin(), sentryConfig],
   });
 
   let serverIsReady = false;

--- a/graphql/src/schemas/actor.ts
+++ b/graphql/src/schemas/actor.ts
@@ -8,7 +8,7 @@ export const actorSchema = gql`
     name: String
     identificationStrength: IdentificationStrength
     contactDetails: ContactInfo
-    preferredLanguages: [Language!]
+    preferredLanguages: [UnifiedSearchLanguageEnum!]
     preferredMedium: ContactMedium
   }
   enum IdentificationStrength {

--- a/graphql/src/schemas/actor.ts
+++ b/graphql/src/schemas/actor.ts
@@ -1,5 +1,8 @@
-export const actorSchema = `
-  """TODO: take from Profile"""
+import { gql } from 'graphql-tag';
+export const actorSchema = gql`
+  """
+  TODO: take from Profile
+  """
   type Person {
     meta: NodeMeta
     name: String
@@ -20,7 +23,9 @@ export const actorSchema = `
     "If the person has proved their legal identity"
     LEGALLY_CONNECTED
   }
-  """TODO: merge beta.kultus organisation, etc"""
+  """
+  TODO: merge beta.kultus organisation, etc
+  """
   type Organisation {
     meta: NodeMeta
     contactDetails: ContactInfo
@@ -37,8 +42,7 @@ export const actorSchema = `
   Contact details for a person, legal entity, venue or project
   """
   type ContactInfo
-    @origin(service: "linked", type: "event", attr: "provider_contact_info")
-  {
+    @origin(service: "linked", type: "event", attr: "provider_contact_info") {
     contactUrl: String
     phoneNumbers: [PhoneNumber!]!
     emailAddresses: [String!]!
@@ -48,7 +52,9 @@ export const actorSchema = `
     countryCode: String!
     restNumber: String!
   }
-  """TODO: give real structure"""
+  """
+  TODO: give real structure
+  """
   type Address {
     postalCode: String
     streetAddress: LanguageString

--- a/graphql/src/schemas/es.ts
+++ b/graphql/src/schemas/es.ts
@@ -1,42 +1,42 @@
-export const elasticSearchSchema = `
+import { gql } from 'graphql-tag';
+export const elasticSearchSchema = gql`
+  """
+   Elasticsearch results
+  """
+  type ElasticSearchResult {
+    took: Int
+    timed_out: Boolean
+    _shards: Shards
+    hits: Hits
+  }
 
-""" Elasticsearch results """
+  type Shards {
+    total: Int
+    successful: Int
+    skipped: Int
+    failed: Int
+  }
 
-type ElasticSearchResult {
-  took: Int,
-  timed_out: Boolean,
-  _shards: Shards
-  hits: Hits
-}
+  type Hits {
+    max_score: Float
+    total: HitTotal
+    hits: [SingleHit]
+  }
 
-type Shards {
-  total: Int,
-  successful: Int,
-  skipped: Int,
-  failed: Int
-}
+  type HitTotal {
+    value: Int
+    relation: String
+  }
 
-type Hits {
-  max_score: Float,
-  total: HitTotal,
-  hits: [SingleHit],
-}
+  type SingleHit {
+    _index: String
+    _type: String
+    _score: Float
+    _id: String
+    _source: RawJSON
+  }
 
-type HitTotal {
-  value: Int,
-  relation: String
-}
-
-type SingleHit {
-  _index: String,
-  _type: String,
-  _score: Float
-  _id: String,
-  _source: RawJSON
-}
-
-type RawJSON {
-  data: String
-}
-
+  type RawJSON {
+    data: String
+  }
 `;

--- a/graphql/src/schemas/event.ts
+++ b/graphql/src/schemas/event.ts
@@ -29,7 +29,7 @@ export const eventSchema = gql`
     published: DateTime
       @origin(service: "linked", type: "event", attr: "date_published")
     contactPerson: LegalEntity
-    eventLanguages: [Language!]!
+    eventLanguages: [UnifiedSearchLanguageEnum!]!
       @origin(service: "linked", type: "event", attr: "in_language")
     subEvents: [Event!]!
       @origin(service: "linked", type: "event", attr: "sub_events")

--- a/graphql/src/schemas/event.ts
+++ b/graphql/src/schemas/event.ts
@@ -1,4 +1,5 @@
-export const eventSchema = `
+import { gql } from 'graphql-tag';
+export const eventSchema = gql`
   """
   An organised event - something that happens at a specific time, has a
   specific topic or content, and people can participate.  Examples include
@@ -8,38 +9,39 @@ export const eventSchema = `
   """
   type Event {
     meta: NodeMeta
-    name: LanguageString
-	@origin(service: "linked", type: "event", attr: "name")
+    name: LanguageString @origin(service: "linked", type: "event", attr: "name")
     description: LanguageString
-	@origin(service: "linked", type: "event", attr: "description")
+      @origin(service: "linked", type: "event", attr: "description")
     shortDescription: String
-	@origin(service: "linked", type: "event", attr: "short_description")
+      @origin(service: "linked", type: "event", attr: "short_description")
     descriptionResources: DescriptionResources
-    keywords: [Keyword!]!
-	@origin(service: "linked", type: "event", attr: "keywords")
+    keywords: [KeywordString!]!
+      @origin(service: "linked", type: "event", attr: "keywords")
     eventDataSource: String
-	@origin(service: "linked", type: "event", attr: "data_source")
+      @origin(service: "linked", type: "event", attr: "data_source")
     occurrences: [EventOccurrence!]!
     pricing: [EventPricing!]
-	@origin(service: "linked", type: "event", attr: "offers")
+      @origin(service: "linked", type: "event", attr: "offers")
     organiser: LegalEntity
-	@origin(service: "linked", type: "event", attr: "provider")
+      @origin(service: "linked", type: "event", attr: "provider")
     publisher: LegalEntity
-	@origin(service: "linked", type: "event", attr: "publisher")
+      @origin(service: "linked", type: "event", attr: "publisher")
     published: DateTime
-	@origin(service: "linked", type: "event", attr: "date_published")
+      @origin(service: "linked", type: "event", attr: "date_published")
     contactPerson: LegalEntity
     eventLanguages: [Language!]!
-	@origin(service: "linked", type: "event", attr: "in_language")
+      @origin(service: "linked", type: "event", attr: "in_language")
     subEvents: [Event!]!
-	@origin(service: "linked", type: "event", attr: "sub_events")
+      @origin(service: "linked", type: "event", attr: "sub_events")
     superEvent: Event
-	@origin(service: "linked", type: "event", attr: "super_event")
+      @origin(service: "linked", type: "event", attr: "super_event")
     enrolmentPolicy: EnrolmentPolicy
-    targetAudience: [Keyword!]
-	@origin(service: "linked", type: "event", attr: "audience")
+    targetAudience: [KeywordString!]
+      @origin(service: "linked", type: "event", attr: "audience")
   }
-  """TODO: improve (a lot) over Linked events' offer type"""
+  """
+  TODO: improve (a lot) over Linked events' offer type
+  """
   type EventPricing {
     meta: NodeMeta
     todo: String
@@ -56,16 +58,28 @@ export const eventSchema = `
     """
     estimatedAttendeeCount: Int
     location: LocationDescription
-	@origin(service: "linked", type: "event", attr: "location")
+      @origin(service: "linked", type: "event", attr: "location")
     status: EventOccurrenceStatus
-	@origin(service: "linked", type: "event", attr: "event_status")
+      @origin(service: "linked", type: "event", attr: "event_status")
     enrolments: [Enrolment!]!
     minimumAttendeeCount: Int
-	@origin(service: "linked", type: "extension_course", attr: "minimum_attendee_capacity")
+      @origin(
+        service: "linked"
+        type: "extension_course"
+        attr: "minimum_attendee_capacity"
+      )
     maximumAttendeeCount: Int
-	@origin(service: "linked", type: "extension_course", attr: "maximum_attendee_capacity")
+      @origin(
+        service: "linked"
+        type: "extension_course"
+        attr: "maximum_attendee_capacity"
+      )
     currentlyAvailableParticipantCount: Int
-	@origin(service: "linked", type: "extension_course", attr: "remaining_attendee_capacity")
+      @origin(
+        service: "linked"
+        type: "extension_course"
+        attr: "remaining_attendee_capacity"
+      )
     "for events where equipment is requested from the City of Helsinki"
     cityEquipmentRequests: [EquipmentRequest!]
   }
@@ -83,13 +97,21 @@ export const eventSchema = `
     meta: NodeMeta
     type: [EnrolmentPolicyType!]!
     enrolmentTime: TimeDescription
-	@origin(service: "linked", type: "extension_course", attr: "enrolment_start_time")
-	@origin(service: "linked", type: "extension_course", attr: "enrolment_end_time")
-    allowedParticipantCategories: [Keyword!]!
+      @origin(
+        service: "linked"
+        type: "extension_course"
+        attr: "enrolment_start_time"
+      )
+      @origin(
+        service: "linked"
+        type: "extension_course"
+        attr: "enrolment_end_time"
+      )
+    allowedParticipantCategories: [KeywordString!]!
     participantMinimumAge: Int!
-	@origin(service: "linked", type: "event", attr: "audience_min_age")
+      @origin(service: "linked", type: "event", attr: "audience_min_age")
     participantMaximumAge: Int!
-	@origin(service: "linked", type: "event", attr: "audience_max_age")
+      @origin(service: "linked", type: "event", attr: "audience_max_age")
     "minimum number of people who can enrol together (at the same time)"
     minimumEnrolmentCount: Int
     "maximum number of people who can enrol together (at the same time)"
@@ -110,7 +132,7 @@ export const eventSchema = `
     enroller: Person
     participantCount: Int!
     participants: [Person!]
-    participantCategory: Keyword
+    participantCategory: KeywordString
     overseerCount: Int
     overseers: [Person!]
     requestedMethodOfNotification: ContactMedium

--- a/graphql/src/schemas/geojson.ts
+++ b/graphql/src/schemas/geojson.ts
@@ -1,125 +1,155 @@
 // This schema was automatically generated from a running
 // https://github.com/ghengeveld/graphql-geojson-demo instance by the
 // `get-graphql-schema` tool.
-
-export const geoSchema = `
-"""Coordinate Reference System (CRS) object."""
-type GeoJSONCoordinateReferenceSystem {
-  type: GeoJSONCRSType!
-  properties: GeoJSONCRSProperties!
-}
-"""A (multidimensional) set of coordinates following x, y, z order."""
-scalar GeoJSONCoordinates
-"""CRS object properties."""
-union GeoJSONCRSProperties = GeoJSONNamedCRSProperties | GeoJSONLinkedCRSProperties
-"""Enumeration of all GeoJSON CRS object types."""
-enum GeoJSONCRSType {
-  name
-  link
-}
-"""
-An object that links a geometry to properties in order to provide context.
-"""
-type GeoJSONFeature implements GeoJSONInterface {
-  type: GeoJSONType!
-  crs: GeoJSONCoordinateReferenceSystem!
-  bbox: [Float]
-  geometry: GeoJSONGeometryInterface @cacheControl(inheritMaxAge: true)
-  properties: JSONObject
-  id: String
-}
-"""A set of multiple features."""
-type GeoJSONFeatureCollection implements GeoJSONInterface {
-  type: GeoJSONType!
-  crs: GeoJSONCoordinateReferenceSystem!
-  bbox: [Float]
-  features: [GeoJSONFeature!]!
-}
-"""A set of multiple geometries, possibly of various types."""
-type GeoJSONGeometryCollection implements GeoJSONInterface {
-  type: GeoJSONType!
-  crs: GeoJSONCoordinateReferenceSystem!
-  bbox: [Float]
-  geometries: [GeoJSONGeometryInterface!]!
-}
-interface GeoJSONGeometryInterface {
-  type: GeoJSONType!
-  crs: GeoJSONCoordinateReferenceSystem!
-  bbox: [Float]
-  coordinates: GeoJSONCoordinates
-}
-interface GeoJSONInterface {
-  type: GeoJSONType!
-  crs: GeoJSONCoordinateReferenceSystem!
-  bbox: [Float]
-}
-"""Object describing a single connected sequence of geographical points."""
-type GeoJSONLineString implements GeoJSONInterface & GeoJSONGeometryInterface {
-  type: GeoJSONType!
-  crs: GeoJSONCoordinateReferenceSystem!
-  bbox: [Float]
-  coordinates: GeoJSONCoordinates
-}
-"""Properties for link based CRS object."""
-type GeoJSONLinkedCRSProperties {
-  href: String!
-  type: String
-}
-"""Object describing multiple connected sequences of geographical points."""
-type GeoJSONMultiLineString implements GeoJSONInterface & GeoJSONGeometryInterface {
-  type: GeoJSONType!
-  crs: GeoJSONCoordinateReferenceSystem!
-  bbox: [Float]
-  coordinates: GeoJSONCoordinates
-}
-"""Object describing multiple geographical points."""
-type GeoJSONMultiPoint implements GeoJSONInterface & GeoJSONGeometryInterface {
-  type: GeoJSONType!
-  crs: GeoJSONCoordinateReferenceSystem!
-  bbox: [Float]
-  coordinates: GeoJSONCoordinates
-}
-"""
-Object describing multiple shapes formed by sets of geographical points.
-"""
-type GeoJSONMultiPolygon implements GeoJSONInterface & GeoJSONGeometryInterface {
-  type: GeoJSONType!
-  crs: GeoJSONCoordinateReferenceSystem!
-  bbox: [Float]
-  coordinates: GeoJSONCoordinates
-}
-"""Properties for name based CRS object."""
-type GeoJSONNamedCRSProperties {
-  name: String!
-}
-"""Object describing a single geographical point."""
-type GeoJSONPoint implements GeoJSONInterface & GeoJSONGeometryInterface {
-  type: GeoJSONType!
-  crs: GeoJSONCoordinateReferenceSystem!
-  bbox: [Float]
-  coordinates: GeoJSONCoordinates
-}
-"""
-Object describing a single shape formed by a set of geographical points.
-"""
-type GeoJSONPolygon implements GeoJSONInterface & GeoJSONGeometryInterface {
-  type: GeoJSONType!
-  crs: GeoJSONCoordinateReferenceSystem!
-  bbox: [Float]
-  coordinates: GeoJSONCoordinates
-}
-"""Enumeration of all GeoJSON object types."""
-enum GeoJSONType {
-  Point
-  MultiPoint
-  LineString
-  MultiLineString
-  Polygon
-  MultiPolygon
-  GeometryCollection
-  Feature
-  FeatureCollection
-}
-"""Arbitrary JSON value"""
-scalar JSONObject
+import { gql } from 'graphql-tag';
+export const geoSchema = gql`
+  """
+  Coordinate Reference System (CRS) object.
+  """
+  type GeoJSONCoordinateReferenceSystem {
+    type: GeoJSONCRSType!
+    properties: GeoJSONCRSProperties!
+  }
+  """
+  A (multidimensional) set of coordinates following x, y, z order.
+  """
+  scalar GeoJSONCoordinates
+  """
+  CRS object properties.
+  """
+  union GeoJSONCRSProperties =
+      GeoJSONNamedCRSProperties
+    | GeoJSONLinkedCRSProperties
+  """
+  Enumeration of all GeoJSON CRS object types.
+  """
+  enum GeoJSONCRSType {
+    name
+    link
+  }
+  """
+  An object that links a geometry to properties in order to provide context.
+  """
+  type GeoJSONFeature implements GeoJSONInterface {
+    type: GeoJSONType!
+    crs: GeoJSONCoordinateReferenceSystem!
+    bbox: [Float]
+    geometry: GeoJSONGeometryInterface @cacheControl(inheritMaxAge: true)
+    properties: JSONObject
+    id: String
+  }
+  """
+  A set of multiple features.
+  """
+  type GeoJSONFeatureCollection implements GeoJSONInterface {
+    type: GeoJSONType!
+    crs: GeoJSONCoordinateReferenceSystem!
+    bbox: [Float]
+    features: [GeoJSONFeature!]!
+  }
+  """
+  A set of multiple geometries, possibly of various types.
+  """
+  type GeoJSONGeometryCollection implements GeoJSONInterface {
+    type: GeoJSONType!
+    crs: GeoJSONCoordinateReferenceSystem!
+    bbox: [Float]
+    geometries: [GeoJSONGeometryInterface!]!
+  }
+  interface GeoJSONGeometryInterface {
+    type: GeoJSONType!
+    crs: GeoJSONCoordinateReferenceSystem!
+    bbox: [Float]
+    coordinates: GeoJSONCoordinates
+  }
+  interface GeoJSONInterface {
+    type: GeoJSONType!
+    crs: GeoJSONCoordinateReferenceSystem!
+    bbox: [Float]
+  }
+  """
+  Object describing a single connected sequence of geographical points.
+  """
+  type GeoJSONLineString implements GeoJSONInterface & GeoJSONGeometryInterface {
+    type: GeoJSONType!
+    crs: GeoJSONCoordinateReferenceSystem!
+    bbox: [Float]
+    coordinates: GeoJSONCoordinates
+  }
+  """
+  Properties for link based CRS object.
+  """
+  type GeoJSONLinkedCRSProperties {
+    href: String!
+    type: String
+  }
+  """
+  Object describing multiple connected sequences of geographical points.
+  """
+  type GeoJSONMultiLineString implements GeoJSONInterface & GeoJSONGeometryInterface {
+    type: GeoJSONType!
+    crs: GeoJSONCoordinateReferenceSystem!
+    bbox: [Float]
+    coordinates: GeoJSONCoordinates
+  }
+  """
+  Object describing multiple geographical points.
+  """
+  type GeoJSONMultiPoint implements GeoJSONInterface & GeoJSONGeometryInterface {
+    type: GeoJSONType!
+    crs: GeoJSONCoordinateReferenceSystem!
+    bbox: [Float]
+    coordinates: GeoJSONCoordinates
+  }
+  """
+  Object describing multiple shapes formed by sets of geographical points.
+  """
+  type GeoJSONMultiPolygon implements GeoJSONInterface & GeoJSONGeometryInterface {
+    type: GeoJSONType!
+    crs: GeoJSONCoordinateReferenceSystem!
+    bbox: [Float]
+    coordinates: GeoJSONCoordinates
+  }
+  """
+  Properties for name based CRS object.
+  """
+  type GeoJSONNamedCRSProperties {
+    name: String!
+  }
+  """
+  Object describing a single geographical point.
+  """
+  type GeoJSONPoint implements GeoJSONInterface & GeoJSONGeometryInterface {
+    type: GeoJSONType!
+    crs: GeoJSONCoordinateReferenceSystem!
+    bbox: [Float]
+    coordinates: GeoJSONCoordinates
+  }
+  """
+  Object describing a single shape formed by a set of geographical points.
+  """
+  type GeoJSONPolygon implements GeoJSONInterface & GeoJSONGeometryInterface {
+    type: GeoJSONType!
+    crs: GeoJSONCoordinateReferenceSystem!
+    bbox: [Float]
+    coordinates: GeoJSONCoordinates
+  }
+  """
+  Enumeration of all GeoJSON object types.
+  """
+  enum GeoJSONType {
+    Point
+    MultiPoint
+    LineString
+    MultiLineString
+    Polygon
+    MultiPolygon
+    GeometryCollection
+    Feature
+    FeatureCollection
+  }
+  """
+  Arbitrary JSON value
+  """
+  scalar JSONObject
 `;

--- a/graphql/src/schemas/linkedevents.ts
+++ b/graphql/src/schemas/linkedevents.ts
@@ -1,58 +1,58 @@
-export const linkedeventsSchema = `
+import { gql } from 'graphql-tag';
+export const linkedeventsSchema = gql`
+  type LinkedeventsPlace {
+    """
+    Raw Linkedevents Place fields
+    """
+    origin: String
 
-type LinkedeventsPlace {
-    """ Raw Linkedevents Place fields """
+    id: String
+    data_source: String
+    publisher: String
 
-    origin: String,
-
-    id: String,
-    data_source: String,
-    publisher: String,
-    
-    divisions: [LinkedeventsPlaceDivision],
-    created_time: String,
-    last_modified_time: String,
-    custom_data: String,
-    email: String,
-    contact_type: String,
-    address_region: String,
-    postal_code: String,
-    post_office_box_num: String,
-    address_country: String,
-    deleted: Boolean,
-    has_upcoming_events: Boolean,
-    n_events: Int,
-    image: String,
-    parent: String,
-    replaced_by: String,
-    position: LinkedeventsPlacePosition,
-    address_locality: LinkedeventsPlaceLocalityString,
-    info_url: LinkedeventsPlaceLocalityString,
-    description: LinkedeventsPlaceLocalityString,
-    telephone: String,
-    street_address: LinkedeventsPlaceLocalityString,
+    divisions: [LinkedeventsPlaceDivision]
+    created_time: String
+    last_modified_time: String
+    custom_data: String
+    email: String
+    contact_type: String
+    address_region: String
+    postal_code: String
+    post_office_box_num: String
+    address_country: String
+    deleted: Boolean
+    has_upcoming_events: Boolean
+    n_events: Int
+    image: String
+    parent: String
+    replaced_by: String
+    position: LinkedeventsPlacePosition
+    address_locality: LinkedeventsPlaceLocalityString
+    info_url: LinkedeventsPlaceLocalityString
+    description: LinkedeventsPlaceLocalityString
+    telephone: String
+    street_address: LinkedeventsPlaceLocalityString
     name: LinkedeventsPlaceLocalityString
-    _at_id: String,
-    _at_context: String,
+    _at_id: String
+    _at_context: String
     _at_type: String
-}
+  }
 
-type LinkedeventsPlaceDivision {
-    type: String,
-    ocd_id: String,
-    municipality: String,
+  type LinkedeventsPlaceDivision {
+    type: String
+    ocd_id: String
+    municipality: String
     name: LinkedeventsPlaceLocalityString
-}
+  }
 
-type LinkedeventsPlacePosition {
-    type: String, 
+  type LinkedeventsPlacePosition {
+    type: String
     coordinates: [Float]
-}
+  }
 
-type LinkedeventsPlaceLocalityString {
-    fi: String,
-    sv: String,
+  type LinkedeventsPlaceLocalityString {
+    fi: String
+    sv: String
     en: String
-}
-
+  }
 `;

--- a/graphql/src/schemas/location.ts
+++ b/graphql/src/schemas/location.ts
@@ -1,4 +1,5 @@
-export const locationSchema = `
+import { gql } from 'graphql-tag';
+export const locationSchema = gql`
   """
   A place that forms a unit and can be used for some specific purpose -
   respa unit or resource, service map unit, beta.kultus venue, linked
@@ -19,7 +20,7 @@ export const locationSchema = `
     arrivalInstructions: String
     additionalInfo: String
     facilities: [VenueFacility!]
-    images: [Image]
+    images: [LocationImage]
     ontologyWords: [OntologyWord]
   }
   """
@@ -30,20 +31,24 @@ export const locationSchema = `
     geoLocation: GeoJSONFeature @cacheControl(inheritMaxAge: true)
     address: Address
     explanation: String
-    @origin(service: "linked", type: "event", attr: "location_extra_info")
+      @origin(service: "linked", type: "event", attr: "location_extra_info")
     administrativeDivisions: [AdministrativeDivision]
     venue: Venue
   }
-  """TODO: take this from service map / TPREK"""
+  """
+  TODO: take this from service map / TPREK
+  """
   type AccessibilityProfile {
     meta: NodeMeta
     todo: String
   }
-  """TODO: combine beta.kultus Venue stuff with respa equipment type"""
+  """
+  TODO: combine beta.kultus Venue stuff with respa equipment type
+  """
   type VenueFacility {
     meta: NodeMeta
     name: String!
-    categories: [Keyword!]
+    categories: [KeywordString!]
   }
   type OpeningHours {
     url: String
@@ -52,7 +57,7 @@ export const locationSchema = `
     data: [OpeningHoursDay]
   }
 
-  type Image {
+  type LocationImage {
     url: String
     caption: LanguageString
   }

--- a/graphql/src/schemas/ontology.ts
+++ b/graphql/src/schemas/ontology.ts
@@ -1,4 +1,5 @@
-export const ontologySchema = `
+import { gql } from 'graphql-tag';
+export const ontologySchema = gql`
   type OntologyTree {
     id: ID
     parentId: ID

--- a/graphql/src/schemas/palvelukartta.ts
+++ b/graphql/src/schemas/palvelukartta.ts
@@ -1,67 +1,67 @@
-export const palvelukarttaSchema = `
+import { gql } from 'graphql-tag';
+export const palvelukarttaSchema = gql`
+  type PalvelukarttaUnit {
+    """
+    Raw palvelukartta Unit fields
+    """
+    origin: String
 
-type PalvelukarttaUnit {
-    """ Raw palvelukartta Unit fields """
-
-    origin: String,
-
-    id: Int,
-    org_id: String,
-    dept_id: String,
-    provider_type: String,
-    organizer_type: String,
-    organizer_name: String,
-    data_source_url: String,
-    name_fi: String,
-    name_sv: String,
-    name_en: String,
-    ontologyword_ids: [ Int ],
-    ontologytree_ids: [ Int ],
-    desc_fi: String,
-    desc_sv: String,
-    desc_en: String,
-    latitude: Float,
-    longitude: Float,
-    northing_etrs_gk25: Int,
-    easting_etrs_gk25: Int,
-    northing_etrs_tm35fin: Int,
-    easting_etrs_tm35fin: Int,
+    id: Int
+    org_id: String
+    dept_id: String
+    provider_type: String
+    organizer_type: String
+    organizer_name: String
+    data_source_url: String
+    name_fi: String
+    name_sv: String
+    name_en: String
+    ontologyword_ids: [Int]
+    ontologytree_ids: [Int]
+    desc_fi: String
+    desc_sv: String
+    desc_en: String
+    latitude: Float
+    longitude: Float
+    northing_etrs_gk25: Int
+    easting_etrs_gk25: Int
+    northing_etrs_tm35fin: Int
+    easting_etrs_tm35fin: Int
     manual_coordinates: Boolean
-    street_address_fi: String,
-    street_address_sv: String,
-    street_address_en: String,
-    address_zip: String,
-    address_city_fi: String,
-    address_city_sv: String,
-    address_city_en: String,
-    phone: String,
-    call_charge_info_fi: String,
-    call_charge_info_sv: String,
-    call_charge_info_en: String,
-    www_fi: String,
-    www_sv: String,
-    www_en: String,
-    picture_url: String,
-    picture_caption_fi: String,
-    picture_caption_sv: String,
-    picture_caption_en: String,
-    extra_searchwords_en: String,
-    accessibility_viewpoints: String,
-    created_time: String,
-    modified_time: String,
+    street_address_fi: String
+    street_address_sv: String
+    street_address_en: String
+    address_zip: String
+    address_city_fi: String
+    address_city_sv: String
+    address_city_en: String
+    phone: String
+    call_charge_info_fi: String
+    call_charge_info_sv: String
+    call_charge_info_en: String
+    www_fi: String
+    www_sv: String
+    www_en: String
+    picture_url: String
+    picture_caption_fi: String
+    picture_caption_sv: String
+    picture_caption_en: String
+    extra_searchwords_en: String
+    accessibility_viewpoints: String
+    created_time: String
+    modified_time: String
 
     ontologyword_ids_enriched: [Ontologyword]
-}
+  }
 
-type Ontologyword {
-    id: Int,
-    ontologyword_fi: String,
-    ontologyword_sv: String,
-    ontologyword_en: String,
-    can_add_schoolyear: Boolean,
-    can_add_clarification: Boolean,
-    extra_searchwords_fi: String,
+  type Ontologyword {
+    id: Int
+    ontologyword_fi: String
+    ontologyword_sv: String
+    ontologyword_en: String
+    can_add_schoolyear: Boolean
+    can_add_clarification: Boolean
+    extra_searchwords_fi: String
     unit_ids: [Int]
-}
-
+  }
 `;

--- a/graphql/src/schemas/query.ts
+++ b/graphql/src/schemas/query.ts
@@ -1,6 +1,6 @@
-export const querySchema = `
-
-""" Query """
+import { gql } from 'graphql-tag';
+export const querySchema = gql`
+  extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable"])
 
   directive @origin(service: String, type: String, attr: String) repeatable on FIELD_DEFINITION | OBJECT
 

--- a/graphql/src/schemas/reservation.ts
+++ b/graphql/src/schemas/reservation.ts
@@ -1,6 +1,8 @@
-export const reservationSchema = `
-  
-  """TODO: this comes from respa resource/unit types"""
+import { gql } from 'graphql-tag';
+export const reservationSchema = gql`
+  """
+  TODO: this comes from respa resource/unit types
+  """
   type VenueReservationPolicy {
     todo: String
   }

--- a/graphql/src/schemas/shared.ts
+++ b/graphql/src/schemas/shared.ts
@@ -16,7 +16,7 @@ export const sharedSchema = gql`
   """
   TODO: take from Profile or external source
   """
-  enum Language {
+  enum UnifiedSearchLanguageEnum {
     FI
   }
   """

--- a/graphql/src/schemas/shared.ts
+++ b/graphql/src/schemas/shared.ts
@@ -1,20 +1,28 @@
-export const sharedSchema = `
+import { gql } from 'graphql-tag';
+export const sharedSchema = gql`
   scalar DateTime
   type NodeMeta @cacheControl(inheritMaxAge: true) {
     id: ID!
     createdAt: DateTime
     updatedAt: DateTime
   }
-  """TODO: merge all free tags, categories, and keywords"""
-  type Keyword {
+  """
+  TODO: merge all free tags, categories, and keywords
+  KEYWORDS ARE GIVEN FROM events-proxy (https://tapahtumat-proxy.test.kuva.hel.ninja/proxy/graphql)
+  """
+  type KeywordString {
     name: String!
   }
-  """TODO: take from Profile or external source"""
+  """
+  TODO: take from Profile or external source
+  """
   enum Language {
     FI
   }
-  """TODO: convert all String's to LanguageString's if linguistic content"""
-  type LanguageString @cacheControl(inheritMaxAge: true){
+  """
+  TODO: convert all String's to LanguageString's if linguistic content
+  """
+  type LanguageString @cacheControl(inheritMaxAge: true) {
     fi: String
     sv: String
     en: String
@@ -24,9 +32,8 @@ export const sharedSchema = `
   """
   type TimeDescription {
     starting: DateTime
-	@origin(service: "linked", type: "event", attr: "start_time")
-    ending: DateTime
-	@origin(service: "linked", type: "event", attr: "end_time")
+      @origin(service: "linked", type: "event", attr: "start_time")
+    ending: DateTime @origin(service: "linked", type: "event", attr: "end_time")
     otherTime: TimeDescription
   }
   """
@@ -35,13 +42,15 @@ export const sharedSchema = `
   """
   type DescriptionResources {
     mediaResources: [MediaResource!]!
-	@origin(service: "linked", type: "event", attr: "images")
-	@origin(service: "linked", type: "event", attr: "videos")
+      @origin(service: "linked", type: "event", attr: "images")
+      @origin(service: "linked", type: "event", attr: "videos")
     infoUrls: [String!]!
-	@origin(service: "linked", type: "event", attr: "info_url")
+      @origin(service: "linked", type: "event", attr: "info_url")
     externalLinks: [String!]!
   }
-  """TODO: take this from Linked events Image type."""
+  """
+  TODO: take this from Linked events Image type.
+  """
   type MediaResource {
     meta: NodeMeta
     todo: String

--- a/graphql/yarn.lock
+++ b/graphql/yarn.lock
@@ -2,10 +2,23 @@
 # yarn lockfile v1
 
 
-"@apollo/protobufjs@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@apollo/protobufjs/-/protobufjs-1.2.2.tgz#4bd92cd7701ccaef6d517cdb75af2755f049f87c"
-  integrity sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==
+"@apollo/cache-control-types@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@apollo/cache-control-types/-/cache-control-types-1.0.2.tgz#f42ed3563acc7f1f50617d65d208483977adc68e"
+  integrity sha512-Por80co1eUm4ATsvjCOoS/tIR8PHxqVjsA6z76I6Vw0rFn4cgyVElQcmQDIZiYsy41k8e5xkrMRECkM2WR8pNw==
+
+"@apollo/federation-internals@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@apollo/federation-internals/-/federation-internals-2.1.4.tgz#aa475c51fbc91d9e37e9a6e69446412ab8e32b88"
+  integrity sha512-Fpln5hHEh0Jjy0vaTpIlv1SF+zg2cjunsH2X5QDHwKOXoHsT4o7LF+Duoy7LgZj6W3HNW9Z/srmuOXXNTl2gjw==
+  dependencies:
+    chalk "^4.1.0"
+    js-levenshtein "^1.1.6"
+
+"@apollo/protobufjs@1.2.6":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@apollo/protobufjs/-/protobufjs-1.2.6.tgz#d601e65211e06ae1432bf5993a1a0105f2862f27"
+  integrity sha512-Wqo1oSHNUj/jxmsVp4iR3I480p6qdqHikn38lKrFhfzcDJ7lwd7Ck7cHRl4JE81tWNArl77xhnG/OkZhxKBYOw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -21,10 +34,70 @@
     "@types/node" "^10.1.0"
     long "^4.0.0"
 
-"@apollographql/apollo-tools@^0.5.1":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@apollographql/apollo-tools/-/apollo-tools-0.5.2.tgz#01750a655731a198c3634ee819c463254a7c7767"
-  integrity sha512-KxZiw0Us3k1d0YkJDhOpVH5rJ+mBfjXcgoRoCcslbgirjgLotKMzOcx4PZ7YTEvvEROmvG7X3Aon41GvMmyGsw==
+"@apollo/subgraph@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@apollo/subgraph/-/subgraph-2.1.4.tgz#a8e0c0eb0e2d6a7f8869dfecf8e0d07ed5236712"
+  integrity sha512-WrZuvCtTjLczkJq9BxyGgGB5lE0vr83ZFvbdVdByve+EbvfCh0rNtXNFaAXOkOcqzMcDv258AN44o7WBm+raYw==
+  dependencies:
+    "@apollo/cache-control-types" "^1.0.2"
+    "@apollo/federation-internals" "^2.1.4"
+
+"@apollo/utils.dropunuseddefinitions@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-1.1.0.tgz#02b04006442eaf037f4c4624146b12775d70d929"
+  integrity sha512-jU1XjMr6ec9pPoL+BFWzEPW7VHHulVdGKMkPAMiCigpVIT11VmCbnij0bWob8uS3ODJ65tZLYKAh/55vLw2rbg==
+
+"@apollo/utils.keyvaluecache@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-1.0.1.tgz#46f310f859067efe9fa126156c6954f8381080d2"
+  integrity sha512-nLgYLomqjVimEzQ4cdvVQkcryi970NDvcRVPfd0OPeXhBfda38WjBq+WhQFk+czSHrmrSp34YHBxpat0EtiowA==
+  dependencies:
+    "@apollo/utils.logger" "^1.0.0"
+    lru-cache "^7.10.1"
+
+"@apollo/utils.logger@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.logger/-/utils.logger-1.0.1.tgz#aea0d1bb7ceb237f506c6bbf38f10a555b99a695"
+  integrity sha512-XdlzoY7fYNK4OIcvMD2G94RoFZbzTQaNP0jozmqqMudmaGo2I/2Jx71xlDJ801mWA/mbYRihyaw6KJii7k5RVA==
+
+"@apollo/utils.printwithreducedwhitespace@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-1.1.0.tgz#c466299a4766eef8577a2a64c8f27712e8bd7e30"
+  integrity sha512-GfFSkAv3n1toDZ4V6u2d7L4xMwLA+lv+6hqXicMN9KELSJ9yy9RzuEXaX73c/Ry+GzRsBy/fdSUGayGqdHfT2Q==
+
+"@apollo/utils.removealiases@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.removealiases/-/utils.removealiases-1.0.0.tgz#75f6d83098af1fcae2d3beb4f515ad4a8452a8c1"
+  integrity sha512-6cM8sEOJW2LaGjL/0vHV0GtRaSekrPQR4DiywaApQlL9EdROASZU5PsQibe2MWeZCOhNrPRuHh4wDMwPsWTn8A==
+
+"@apollo/utils.sortast@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.sortast/-/utils.sortast-1.1.0.tgz#93218c7008daf3e2a0725196085a33f5aab5ad07"
+  integrity sha512-VPlTsmUnOwzPK5yGZENN069y6uUHgeiSlpEhRnLFYwYNoJHsuJq2vXVwIaSmts015WTPa2fpz1inkLYByeuRQA==
+  dependencies:
+    lodash.sortby "^4.7.0"
+
+"@apollo/utils.stripsensitiveliterals@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-1.2.0.tgz#4920651f36beee8e260e12031a0c5863ad0c7b28"
+  integrity sha512-E41rDUzkz/cdikM5147d8nfCFVKovXxKBcjvLEQ7bjZm/cg9zEcXvS6vFY8ugTubI3fn6zoqo0CyU8zT+BGP9w==
+
+"@apollo/utils.usagereporting@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.usagereporting/-/utils.usagereporting-1.0.0.tgz#b81df180f4ca78b91a22cb49105174a7f070db1e"
+  integrity sha512-5PL7hJMkTPmdo3oxPtigRrIyPxDk/ddrUryHPDaezL1lSFExpNzsDd2f1j0XJoHOg350GRd3LyD64caLA2PU1w==
+  dependencies:
+    "@apollo/utils.dropunuseddefinitions" "^1.1.0"
+    "@apollo/utils.printwithreducedwhitespace" "^1.1.0"
+    "@apollo/utils.removealiases" "1.0.0"
+    "@apollo/utils.sortast" "^1.1.0"
+    "@apollo/utils.stripsensitiveliterals" "^1.2.0"
+    apollo-reporting-protobuf "^3.3.1"
+
+"@apollographql/apollo-tools@^0.5.3":
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/@apollographql/apollo-tools/-/apollo-tools-0.5.4.tgz#cb3998c6cf12e494b90c733f44dd9935e2d8196c"
+  integrity sha512-shM3q7rUbNyXVVRkQJQseXv6bnYM3BUma/eZhwXR4xsuM+bqWnJKvW7SAfRjP7LuSCocrexa5AXhjjawNHrIlw==
 
 "@apollographql/graphql-playground-html@1.6.29":
   version "1.6.29"
@@ -1201,6 +1274,14 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@graphql-tools/merge@8.3.11":
+  version "8.3.11"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.3.11.tgz#f5eab764e8d7032c1b7e32d5dc6dea5b2f5bb21e"
+  integrity sha512-IpZh8r8e8FycXaUv04xe5HQH9siD1tkS8MvaO8Wb2FaPXv15XSYP+Wsb2MUStpIqGfQxa6xY/+eEuxv+VqwXyg==
+  dependencies:
+    "@graphql-tools/utils" "9.1.0"
+    tslib "^2.4.0"
+
 "@graphql-tools/merge@^8.2.1":
   version "8.2.1"
   resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.2.1.tgz#bf83aa06a0cfc6a839e52a58057a84498d0d51ff"
@@ -1229,7 +1310,24 @@
     tslib "~2.3.0"
     value-or-promise "1.0.11"
 
-"@graphql-tools/utils@^8.0.0", "@graphql-tools/utils@^8.5.1", "@graphql-tools/utils@^8.6.0":
+"@graphql-tools/schema@^9.0.9":
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-9.0.9.tgz#aa24869a2231039dcd9b6b882a5c5cb186d1116e"
+  integrity sha512-hwg8trUytO5ayQ8bzL3+sAyXcu2rhKt5pLXpLO0/TMTN2nXd3DBO4mqx+Ra4Er2mE/msInGQ5EmZbxVBPv+hSg==
+  dependencies:
+    "@graphql-tools/merge" "8.3.11"
+    "@graphql-tools/utils" "9.1.0"
+    tslib "^2.4.0"
+    value-or-promise "1.0.11"
+
+"@graphql-tools/utils@9.1.0":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-9.1.0.tgz#c33893e0aa9cbd3760d94f1771477e722adb4e54"
+  integrity sha512-4Ketxo98IwKA/56LP6cI6PgQBwUCujszQcTNkzjq7liJPa2mLjKnmVOJ0bauMwKcEazeYuZagceljb0POmEGvQ==
+  dependencies:
+    tslib "^2.4.0"
+
+"@graphql-tools/utils@^8.5.1", "@graphql-tools/utils@^8.6.0":
   version "8.6.1"
   resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.6.1.tgz#52c7eb108f2ca2fd01bdba8eef85077ead1bf882"
   integrity sha512-uxcfHCocp4ENoIiovPxUWZEHOnbXqj3ekWc0rm7fUhW93a1xheARNHcNKhwMTR+UKXVJbTFQdGI1Rl5XdyvDBg==
@@ -1251,6 +1349,13 @@
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
+
+"@jest/schemas@^29.0.0":
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.0.0.tgz#5f47f5994dd4ef067fb7b4188ceac45f77fe952a"
+  integrity sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==
+  dependencies:
+    "@sinclair/typebox" "^0.24.1"
 
 "@jest/transform@^26.6.2":
   version "26.6.2"
@@ -1282,6 +1387,18 @@
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
     "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
+"@jest/types@^29.3.1":
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.3.1.tgz#7c5a80777cb13e703aeec6788d044150341147e3"
+  integrity sha512-d0S0jmmTpjnhCmNpApgX3jrUZgZ22ivKJRvL2lli5hpCRoNnp1f85r2/wpKfXuYu8E7Jjh1hGfhPyup1NM5AmA==
+  dependencies:
+    "@jest/schemas" "^29.0.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
 "@josephg/resolvable@^1.0.0":
@@ -1410,6 +1527,11 @@
     "@sentry/types" "6.16.1"
     tslib "^1.9.3"
 
+"@sinclair/typebox@^0.24.1":
+  version "0.24.51"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.51.tgz#645f33fe4e02defe26f2f5c0410e1c094eac7f5f"
+  integrity sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -1482,7 +1604,16 @@
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.12.tgz#6b2c510a7ad7039e98e7b8d3d6598f4359e5c080"
   integrity sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==
 
-"@types/express-serve-static-core@4.17.27", "@types/express-serve-static-core@^4.17.18":
+"@types/express-serve-static-core@4.17.31":
+  version "4.17.31"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz#a1139efeab4e7323834bb0226e62ac019f474b2f"
+  integrity sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+
+"@types/express-serve-static-core@^4.17.18":
   version "4.17.27"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.27.tgz#7a776191e47295d2a05962ecbb3a4ce97e38b401"
   integrity sha512-e/sVallzUTPdyOTiqi8O8pMdBBphscvI6E4JYaKlja4Lm+zh7UFSSdW5VMkRbhDtmrONqOUHOXRguPsDckzxNA==
@@ -1491,10 +1622,10 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
 
-"@types/express@4.17.13":
-  version "4.17.13"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.13.tgz#a76e2995728999bab51a33fabce1d705a3709034"
-  integrity sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==
+"@types/express@4.17.14":
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.14.tgz#143ea0557249bc1b3b54f15db4c81c3d4eb3569c"
+  integrity sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==
   dependencies:
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "^4.17.18"
@@ -1560,6 +1691,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
   integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
 
+"@types/node@^18.11.9":
+  version "18.11.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
+  integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
+
 "@types/qs@*":
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
@@ -1587,6 +1723,13 @@
   version "15.0.14"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.14.tgz#26d821ddb89e70492160b66d10a0eb6df8f6fb06"
   integrity sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^17.0.8":
+  version "17.0.13"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.13.tgz#34cced675ca1b1d51fcf4d34c3c6f0fa142a5c76"
+  integrity sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -1652,127 +1795,124 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-apollo-datasource-rest@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/apollo-datasource-rest/-/apollo-datasource-rest-3.5.0.tgz#d6aebd1a32f2becd82d49883fd88a72ac5a16a83"
-  integrity sha512-rkYc3EY7Qx/r6fnMHxe4BIoPiTIjYsauQ8zaRFTVi06Wwu84BxYVU5gqjILAj3FpE0klA5AImRqYtG3MWzLrwg==
+apollo-datasource-rest@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/apollo-datasource-rest/-/apollo-datasource-rest-3.7.0.tgz#ee81a72a14731227420ee285d6443e3099b5620d"
+  integrity sha512-MeORtXZtc9drAvsarAGAUI4GZKoYFVc1OXIvehIZ/6pJrOdKGziGbraos2s/A+u8mpNPfbpk7W6f7uKtmwV0AA==
   dependencies:
-    apollo-datasource "^3.3.0"
-    apollo-server-caching "^3.3.0"
-    apollo-server-env "^4.2.0"
-    apollo-server-errors "^3.3.0"
+    "@apollo/utils.keyvaluecache" "^1.0.1"
+    apollo-datasource "^3.3.2"
+    apollo-server-env "^4.2.1"
+    apollo-server-errors "^3.3.1"
     http-cache-semantics "^4.1.0"
 
-apollo-datasource@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/apollo-datasource/-/apollo-datasource-3.3.0.tgz#ee84a802c45818e6a21a5f2d427f94851a4f9ebe"
-  integrity sha512-It8POTZTOCAnedRj2izEVeySN06LIfojigZjWaOY7voLe0DIgtvhql91xr27fuIWsR/Ew9twO3dLBjjvy34J4Q==
+apollo-datasource@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/apollo-datasource/-/apollo-datasource-3.3.2.tgz#5711f8b38d4b7b53fb788cb4dbd4a6a526ea74c8"
+  integrity sha512-L5TiS8E2Hn/Yz7SSnWIVbZw0ZfEIXZCa5VUiVxD9P53JvSrf4aStvsFDlGWPvpIdCR+aly2CfoB79B9/JjKFqg==
   dependencies:
-    apollo-server-caching "^3.3.0"
-    apollo-server-env "^4.2.0"
+    "@apollo/utils.keyvaluecache" "^1.0.1"
+    apollo-server-env "^4.2.1"
 
-apollo-reporting-protobuf@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.3.0.tgz#2fc0f7508e488851eda8a6e7c8cc3b5a156ab44b"
-  integrity sha512-51Jwrg0NvHJfKz7TIGU8+Os3rUAqWtXeKRsRtKYtTeMSBPNhzz8UoGjAB3XyVmUXRE3IRmLtDPDRFL7qbxMI/w==
+apollo-reporting-protobuf@^3.3.1, apollo-reporting-protobuf@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.3.3.tgz#df2b7ff73422cd682af3f1805d32301aefdd9e89"
+  integrity sha512-L3+DdClhLMaRZWVmMbBcwl4Ic77CnEBPXLW53F7hkYhkaZD88ivbCVB1w/x5gunO6ZHrdzhjq0FHmTsBvPo7aQ==
   dependencies:
-    "@apollo/protobufjs" "1.2.2"
+    "@apollo/protobufjs" "1.2.6"
 
-apollo-server-caching@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/apollo-server-caching/-/apollo-server-caching-3.3.0.tgz#f501cbeb820a4201d98c2b768c085f22848d9dc5"
-  integrity sha512-Wgcb0ArjZ5DjQ7ID+tvxUcZ7Yxdbk5l1MxZL8D8gkyjooOkhPNzjRVQ7ubPoXqO54PrOMOTm1ejVhsF+AfIirQ==
+apollo-server-core@^3.11.1:
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-3.11.1.tgz#89d83aeaa71a59f760ebfa35bb0cbd31e15474ca"
+  integrity sha512-t/eCKrRFK1lYZlc5pHD99iG7Np7CEm3SmbDiONA7fckR3EaB/pdsEdIkIwQ5QBBpT5JLp/nwvrZRVwhaWmaRvw==
   dependencies:
-    lru-cache "^6.0.0"
-
-apollo-server-core@^3.6.1:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-3.6.1.tgz#e835198a2eda5bcb61d2a1174d44ecb0ac414d15"
-  integrity sha512-V2Us5x7d+w8dVdyFLxEygMgaQ3KZ6Z59HpaQBNHQ7C5wVZhjUXIsgbehBtfzQbMpyMx0z5/8Z8eIrC4zNoGJDw==
-  dependencies:
-    "@apollographql/apollo-tools" "^0.5.1"
+    "@apollo/utils.keyvaluecache" "^1.0.1"
+    "@apollo/utils.logger" "^1.0.0"
+    "@apollo/utils.usagereporting" "^1.0.0"
+    "@apollographql/apollo-tools" "^0.5.3"
     "@apollographql/graphql-playground-html" "1.6.29"
     "@graphql-tools/mock" "^8.1.2"
     "@graphql-tools/schema" "^8.0.0"
-    "@graphql-tools/utils" "^8.0.0"
     "@josephg/resolvable" "^1.0.0"
-    apollo-datasource "^3.3.0"
-    apollo-reporting-protobuf "^3.3.0"
-    apollo-server-caching "^3.3.0"
-    apollo-server-env "^4.2.0"
-    apollo-server-errors "^3.3.0"
-    apollo-server-plugin-base "^3.5.0"
-    apollo-server-types "^3.5.0"
+    apollo-datasource "^3.3.2"
+    apollo-reporting-protobuf "^3.3.3"
+    apollo-server-env "^4.2.1"
+    apollo-server-errors "^3.3.1"
+    apollo-server-plugin-base "^3.7.1"
+    apollo-server-types "^3.7.1"
     async-retry "^1.2.1"
     fast-json-stable-stringify "^2.1.0"
     graphql-tag "^2.11.0"
-    lodash.sortby "^4.7.0"
     loglevel "^1.6.8"
     lru-cache "^6.0.0"
+    node-abort-controller "^3.0.1"
     sha.js "^2.4.11"
-    uuid "^8.0.0"
+    uuid "^9.0.0"
+    whatwg-mimetype "^3.0.0"
 
-apollo-server-env@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/apollo-server-env/-/apollo-server-env-4.2.0.tgz#d7cb08a81cee3025cd47b08be80b359d61d85913"
-  integrity sha512-4xJ+PCoWsFLj4rU6iXrIhqD7nI42goi4Iqrhsof9680ljSzkzd+PCwZsja3mHOFXKUQQUvJ7StVSgwaiRu45+A==
+apollo-server-env@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-env/-/apollo-server-env-4.2.1.tgz#ea5b1944accdbdba311f179e4dfaeca482c20185"
+  integrity sha512-vm/7c7ld+zFMxibzqZ7SSa5tBENc4B0uye9LTfjJwGoQFY5xsUPH5FpO5j0bMUDZ8YYNbrF9SNtzc5Cngcr90g==
   dependencies:
-    node-fetch "^2.6.1"
+    node-fetch "^2.6.7"
 
-apollo-server-errors@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-3.3.0.tgz#ac8ceb1400064312f983d8d70195693fbcf2be3c"
-  integrity sha512-9/MNlPZBbEjcCdJcUSbKbVEBT9xZS8GSpX7T/TyzcxHSbsXJszSDSipQNGC+PRKTKAUnv61IONScVyLKEZ5XEQ==
+apollo-server-errors@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-3.3.1.tgz#ba5c00cdaa33d4cbd09779f8cb6f47475d1cd655"
+  integrity sha512-xnZJ5QWs6FixHICXHxUfm+ZWqqxrNuPlQ+kj5m6RtEgIpekOPssH/SD9gf2B4HuWV0QozorrygwZnux8POvyPA==
 
-apollo-server-express@^3.6.1:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-3.6.1.tgz#b8bda303e05c551ac76c9c0b26bc651ca1466912"
-  integrity sha512-29imWvRPn5GsQq02Akt0+jejpWzpOIZfUmgoiFm4YB7somvhDNw15Pu7fv4sISK8ehNIDF68IpLd2cpY8sCkYQ==
+apollo-server-express@^3.11.1:
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-3.11.1.tgz#f46d2f2f8db3d99ede6c0c144fea02f24b73cb78"
+  integrity sha512-x9ngcpXbBlt4naCXTwNtBFb/mOd9OU0wtFXvJkObHF26NsRazu3DxDfEuekA6V1NFOocD+A9jmVMQeQWug5MgA==
   dependencies:
     "@types/accepts" "^1.3.5"
     "@types/body-parser" "1.19.2"
     "@types/cors" "2.8.12"
-    "@types/express" "4.17.13"
-    "@types/express-serve-static-core" "4.17.27"
+    "@types/express" "4.17.14"
+    "@types/express-serve-static-core" "4.17.31"
     accepts "^1.3.5"
-    apollo-server-core "^3.6.1"
-    apollo-server-types "^3.5.0"
+    apollo-server-core "^3.11.1"
+    apollo-server-types "^3.7.1"
     body-parser "^1.19.0"
     cors "^2.8.5"
     parseurl "^1.3.3"
 
-apollo-server-plugin-base@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-3.5.0.tgz#f3cb4f677152b60113f06f8d23b6234ecff847b4"
-  integrity sha512-dpi+W6wexT4H3cjIhxC9SJABkR8TCfxycoHK+U4jxQXUdg50da+KnMgoWlQbF1tuXtUs4gnJtij1RjuGtKwBhw==
+apollo-server-plugin-base@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-3.7.1.tgz#aa78ef49bd114e35906ca9cf7493fed2664cbde8"
+  integrity sha512-g3vJStmQtQvjGI289UkLMfThmOEOddpVgHLHT2bNj0sCD/bbisj4xKbBHETqaURokteqSWyyd4RDTUe0wAUDNQ==
   dependencies:
-    apollo-server-types "^3.5.0"
+    apollo-server-types "^3.7.1"
 
-apollo-server-plugin-response-cache@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/apollo-server-plugin-response-cache/-/apollo-server-plugin-response-cache-3.5.0.tgz#b39db3351b2835ecc43487ec087cf8fc6257a6fb"
-  integrity sha512-9ZFSRAbzuAUnWXEuUWVoUOOHsJL6xb5i7/9YbWIXlXnopOrG4aVISS73npIVxjwvBEXTNiAPxiNRYEd+1gF3hw==
+apollo-server-plugin-response-cache@^3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-plugin-response-cache/-/apollo-server-plugin-response-cache-3.8.1.tgz#2d9559fe9951812dcda77fc2658422028f060af8"
+  integrity sha512-c6bkrZjzX8Ac44CF7a4m9ans2QFV2C0XVUUDnuSWAX3G9ZWbs55NC+H3YtcFhAPoX7gv92RAu88ipMahd8NiUQ==
   dependencies:
-    apollo-server-caching "^3.3.0"
-    apollo-server-plugin-base "^3.5.0"
-    apollo-server-types "^3.5.0"
+    "@apollo/utils.keyvaluecache" "^1.0.1"
+    apollo-server-plugin-base "^3.7.1"
+    apollo-server-types "^3.7.1"
 
-apollo-server-types@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/apollo-server-types/-/apollo-server-types-3.5.0.tgz#82f912d7765152fe1fde86cea8a076e9a0831a9d"
-  integrity sha512-4JaZNu1kjrzIbppgc78hhIe2DFe+XONf8grprcjTOe0v8dIsuV0tFUnl+awTvTpHU1sdjRCKwnj382BebiL+qw==
+apollo-server-types@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-types/-/apollo-server-types-3.7.1.tgz#87adfcb52ec0893999a9cfafd5474bfda7ab0798"
+  integrity sha512-aE9RDVplmkaOj/OduNmGa+0a1B5RIWI0o3zC1zLvBTVWMKTpo0ifVf11TyMkLCY+T7cnZqVqwyShziOyC3FyUw==
   dependencies:
-    apollo-reporting-protobuf "^3.3.0"
-    apollo-server-caching "^3.3.0"
-    apollo-server-env "^4.2.0"
+    "@apollo/utils.keyvaluecache" "^1.0.1"
+    "@apollo/utils.logger" "^1.0.0"
+    apollo-reporting-protobuf "^3.3.3"
+    apollo-server-env "^4.2.1"
 
-apollo-server@^3.3.0:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/apollo-server/-/apollo-server-3.6.1.tgz#29420b1c0cddbf2e18147a3ca7299485f17137a2"
-  integrity sha512-Y2MY2/WvaTiofVoIR5ZIYt6c6wX8klZRaXI9x+7JBiFV9HMcOuLLpU3+P4r2EVXuN1LLe82m1PgiAYr+a1OmQg==
+apollo-server@^3.11.1:
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/apollo-server/-/apollo-server-3.11.1.tgz#831646081323aadf2cb53cdc3401786e41d44d81"
+  integrity sha512-3RZ/veWGbi0zXy2YVaPkYIAavpbHyEVui91DNYvz6UFS0fZmhJwG7f1VmGheeRiqiV8nFa8GuBejI1niTeAYzA==
   dependencies:
-    apollo-server-core "^3.6.1"
-    apollo-server-express "^3.6.1"
+    "@types/express" "4.17.14"
+    apollo-server-core "^3.11.1"
+    apollo-server-express "^3.11.1"
     express "^4.17.1"
 
 arg@^4.1.0:
@@ -2057,7 +2197,7 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-from@1.x, buffer-from@^1.0.0:
+buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
@@ -2171,6 +2311,11 @@ ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
+ci-info@^3.2.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.5.0.tgz#bfac2a29263de4c829d806b1ab478e35091e171f"
+  integrity sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -2824,17 +2969,22 @@ graceful-fs@^4.1.2, graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
-graphql-tag@^2.11.0:
+graceful-fs@^4.2.9:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+
+graphql-tag@^2.11.0, graphql-tag@^2.12.6:
   version "2.12.6"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
   integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
   dependencies:
     tslib "^2.1.0"
 
-graphql@^15.5.0:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.6.0.tgz#e69323c6a9780a1a4b9ddf7e35ca8904bb04df02"
-  integrity sha512-WJR872Zlc9hckiEPhXgyUftXH48jp2EjO5tgBBOyNMRJZ9fviL2mJBD6CAysk6N5S0r9BTs09Qk39nnJBkvOXQ==
+graphql@^16.6.0:
+  version "16.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
+  integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -3244,7 +3394,7 @@ jest-serializer@^26.6.2:
     "@types/node" "*"
     graceful-fs "^4.2.4"
 
-jest-util@^26.1.0, jest-util@^26.6.2:
+jest-util@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.2.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1"
   integrity sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==
@@ -3256,6 +3406,18 @@ jest-util@^26.1.0, jest-util@^26.6.2:
     is-ci "^2.0.0"
     micromatch "^4.0.2"
 
+jest-util@^29.0.0:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.3.1.tgz#1dda51e378bbcb7e3bc9d8ab651445591ed373e1"
+  integrity sha512-7YOVZaiX7RJLv76ZfHt4nbNEzzTRiMW/IiOG7ZOKmTXmoGBxUDefgMAxQubu6WPVqP5zSzAdZG0FfLcC7HOIFQ==
+  dependencies:
+    "@jest/types" "^29.3.1"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
+    picomatch "^2.2.3"
+
 jest-worker@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
@@ -3264,6 +3426,11 @@ jest-worker@^26.6.2:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
+
+js-levenshtein@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -3293,12 +3460,17 @@ json-buffer@3.0.0:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
   integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
 
-json5@2.x, json5@^2.1.2:
+json5@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   dependencies:
     minimist "^1.2.5"
+
+json5@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
+  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
 keyv@^3.0.0:
   version "3.1.0"
@@ -3350,15 +3522,15 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.memoize@4.x:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
-
-lodash@4.x:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loglevel@^1.6.8:
   version "1.8.0"
@@ -3386,6 +3558,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lru-cache@^7.10.1:
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.1.tgz#8da8d2f5f59827edb388e63e459ac23d6d408fea"
+  integrity sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==
 
 lru_map@^0.3.3:
   version "0.3.3"
@@ -3517,11 +3694,6 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@1.x:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -3574,10 +3746,15 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@^2.6.1:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
-  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+node-abort-controller@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.0.1.tgz#f91fa50b1dee3f909afabb7e261b1e1d6b0cb74e"
+  integrity sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw==
+
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -4412,21 +4589,19 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
-ts-jest@^26.5.5:
-  version "26.5.6"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.6.tgz#c32e0746425274e1dfe333f43cd3c800e014ec35"
-  integrity sha512-rua+rCP8DxpA8b4DQD/6X2HQS8Zy/xzViVYfEs2OQu68tkCuKLV0Md8pmX55+W24uRIyAsf/BajRfxOs+R2MKA==
+ts-jest@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.0.3.tgz#63ea93c5401ab73595440733cefdba31fcf9cb77"
+  integrity sha512-Ibygvmuyq1qp/z3yTh9QTwVVAbFdDy/+4BtIQR2sp6baF2SJU/8CKK/hhnGIDY2L90Az2jIqTwZPnN2p+BweiQ==
   dependencies:
     bs-logger "0.x"
-    buffer-from "1.x"
     fast-json-stable-stringify "2.x"
-    jest-util "^26.1.0"
-    json5 "2.x"
-    lodash "4.x"
+    jest-util "^29.0.0"
+    json5 "^2.2.1"
+    lodash.memoize "4.x"
     make-error "1.x"
-    mkdirp "1.x"
     semver "7.x"
-    yargs-parser "20.x"
+    yargs-parser "^21.0.1"
 
 ts-node@^8.3.0:
   version "8.10.2"
@@ -4449,6 +4624,11 @@ tslib@^2.1.0, tslib@~2.3.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
+tslib@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+
 type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
@@ -4469,10 +4649,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^3.5.3:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
-  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
+typescript@^4.8.4:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
+  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
 undefsafe@^2.0.5:
   version "2.0.5"
@@ -4574,10 +4754,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^8.0.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 value-or-promise@1.0.11:
   version "1.0.11"
@@ -4600,6 +4780,11 @@ webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
+whatwg-mimetype@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"
+  integrity sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==
 
 whatwg-url@^5.0.0:
   version "5.0.0"
@@ -4665,10 +4850,10 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yargs-parser@20.x:
-  version "20.2.9"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
-  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+yargs-parser@^21.0.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
The subgraph requirements (https://www.apollographql.com/docs/federation/subgraph-spec/) must be met in the graph that the Apollo-server serves.

1. Upgrade all the Apollo dependencies to the latest.
2. Change the old way of schema creation from `mergeSchemas({ schemas: typeDefs, resolvers })` to `buildSubgraphSchema({ typeDefs, resolvers })`. This is “a function that takes a schema module object (or an array of them) and returns a federation-ready subgraph schema”.
3. Add a new Federation 2 directive to the root Query:
```
export const Query = gql`
  extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable"])
  type Query {
    _empty: String
  }
`;
```
4. The Keyword type and the Location Image type were overlapping with Events-Helsinki-proxy (https://github.com/City-of-Helsinki/events-helsinki-api-proxy). Those needs to be addressed in client apps too.
NOTE: This needs to be tested seriously!