### PR TITLE
Change the type name of the "Venue" to "UnifiedSearchVenue"

### DIFF
--- a/graphql/src/schemas/location.ts
+++ b/graphql/src/schemas/location.ts
@@ -5,13 +5,13 @@ export const locationSchema = gql`
   respa unit or resource, service map unit, beta.kultus venue, linked
   events place, Kukkuu venue
   """
-  type Venue {
+  type UnifiedSearchVenue {
     meta: NodeMeta
     name: LanguageString
     location: LocationDescription @cacheControl(inheritMaxAge: true)
     description: LanguageString
     descriptionResources: DescriptionResources
-    partOf: Venue
+    partOf: UnifiedSearchVenue
     openingHours: OpeningHours
     manager: LegalEntity
     contactDetails: ContactInfo
@@ -33,7 +33,7 @@ export const locationSchema = gql`
     explanation: String
       @origin(service: "linked", type: "event", attr: "location_extra_info")
     administrativeDivisions: [AdministrativeDivision]
-    venue: Venue
+    venue: UnifiedSearchVenue
   }
   """
   TODO: take this from service map / TPREK

--- a/graphql/src/schemas/query.ts
+++ b/graphql/src/schemas/query.ts
@@ -45,7 +45,7 @@ export const querySchema = gql`
   type SearchResultNode {
     _score: Float
     id: ID!
-    venue: Venue @cacheControl(inheritMaxAge: true)
+    venue: UnifiedSearchVenue @cacheControl(inheritMaxAge: true)
     event: Event
     searchCategories: [UnifiedSearchResultCategory!]!
   }


### PR DESCRIPTION
LIIKUNTA-336.
The Venue type name is already taken in the supergraph
where there is TPRek merged in to it.

Related to https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/108, https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/109 and https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/110.

NOTE: The change of this PR should not affect any how to the running production services, because the Unified-Search is in active use only in the Liikunta-Helsinki. 

NOTE 2: The current production version of Liikunta-Helsinki is built from the Liikunta specific old deprecated repo https://github.com/City-of-Helsinki/liikunta-helsinki. The new version of the Liikunta is hosted in https://github.com/City-of-Helsinki/events-helsinki-monorepo. The old deprecated version does not need this change and probably this should not be merged before the Liikunta service is deployed to the production from the monorepo. Anyway, this should affect only in the types generation, and not in the handling of requests anyhow.