### PR TITLE
US-108 | feat: import venues' Respa API resources, e.g. reservability

### DIFF
--- a/graphql/src/schemas/location.ts
+++ b/graphql/src/schemas/location.ts
@@ -11,6 +11,7 @@ export const locationSchema = gql`
     location: LocationDescription @cacheControl(inheritMaxAge: true)
     description: LanguageString
     serviceOwner: ServiceOwner
+    resources: [Resource!]!
     descriptionResources: DescriptionResources
     partOf: Venue
     openingHours: OpeningHours
@@ -86,6 +87,33 @@ export const locationSchema = gql`
     phone: String
     www: String
     viewpoints: [AccessibilityViewpoint]
+  }
+  enum ResourceMainType {
+    item
+    person
+    space
+  }
+  type ResourceType {
+    id: ID
+    mainType: ResourceMainType
+    name: LanguageString
+  }
+  type ResourceUserPermissions {
+    canMakeReservations: Boolean
+  }
+  type Resource {
+    id: ID
+    name: LanguageString
+    description: LanguageString
+    type: ResourceType
+    userPermissions: ResourceUserPermissions
+    reservable: Boolean
+    reservationInfo: LanguageString
+    genericTerms: LanguageString
+    paymentTerms: LanguageString
+    specificTerms: LanguageString
+    responsibleContactInfo: LanguageString
+    externalReservationUrl: String
   }
   """
   TODO: combine beta.kultus Venue stuff with respa equipment type

--- a/sources/ingest/importers/location.py
+++ b/sources/ingest/importers/location.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import functools
 import logging
+from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -149,6 +150,40 @@ class Accessibility:
     viewpoints: List[AccessibilityViewpoint]
 
 
+class ResourceMainType(Enum):
+    ITEM = "item"
+    PERSON = "person"
+    SPACE = "space"
+
+
+@dataclass
+class ResourceType:
+    id: str
+    mainType: str  # ResourceMainType as string to fix OpenSearch serialization
+    name: LanguageString
+
+
+@dataclass
+class ResourceUserPermissions:
+    canMakeReservations: bool
+
+
+@dataclass
+class Resource:
+    id: str
+    name: LanguageString
+    description: LanguageString
+    type: ResourceType
+    userPermissions: ResourceUserPermissions
+    reservable: bool
+    reservationInfo: Optional[LanguageString]
+    genericTerms: Optional[LanguageString]
+    paymentTerms: Optional[LanguageString]
+    specificTerms: Optional[LanguageString]
+    responsibleContactInfo: Optional[LanguageString]
+    externalReservationUrl: Optional[str]
+
+
 @dataclass
 class Venue:
     meta: NodeMeta = None
@@ -156,6 +191,7 @@ class Venue:
     location: Location = None
     description: LanguageString = None
     serviceOwner: Optional[ServiceOwner] = None
+    resources: List[Resource] = field(default_factory=list)
 
     # TODO
     descriptionResources: str = None
@@ -350,6 +386,19 @@ custom_mappings = {
 }
 
 
+def get_respa_resources() -> List[dict]:
+    """
+    Get all resources from Respa API
+    """
+    accumulated_results = []
+    url = "https://api.hel.fi/respa/v1/resource/?format=json&page_size=500"
+    while url:
+        respa_resources = request_json(url, timeout_seconds=120)
+        accumulated_results += respa_resources["results"]
+        url = respa_resources["next"]
+    return accumulated_results
+
+
 def get_accessibility_viewpoint_id_to_name_mapping(
     use_fallback_languages: bool,
 ) -> Dict[str, LanguageString]:
@@ -488,6 +537,70 @@ def get_enriched_accessibility_viewpoints(
     ]
 
 
+def create_resource_type(
+    respa_resource_type: dict, use_fallback_languages: bool
+) -> ResourceType:
+    """
+    Create a ResourceType object from a Respa resource's type.
+    """
+    l = LanguageStringConverter(respa_resource_type, use_fallback_languages)
+    return ResourceType(
+        id=respa_resource_type["id"],
+        mainType=ResourceMainType(respa_resource_type["main_type"]).value,
+        name=l.get_language_string("name"),
+    )
+
+
+def create_resource_user_permissions(
+    respa_user_permissions: dict,
+) -> ResourceUserPermissions:
+    """
+    Create a ResourceUserPermissions object from a Respa user permissions
+    """
+    return ResourceUserPermissions(
+        canMakeReservations=respa_user_permissions["can_make_reservations"],
+    )
+
+
+def create_exportable_resource(
+    respa_resource: dict, use_fallback_languages: bool
+) -> Resource:
+    """
+    Create a Resource object from a Respa resource.
+    """
+    l = LanguageStringConverter(respa_resource, use_fallback_languages)
+    return Resource(
+        id=respa_resource["id"],
+        name=l.get_language_string("name"),
+        description=l.get_language_string("description"),
+        type=create_resource_type(respa_resource["type"], use_fallback_languages),
+        userPermissions=create_resource_user_permissions(
+            respa_resource["user_permissions"]
+        ),
+        reservable=respa_resource["reservable"],
+        reservationInfo=l.get_language_string("reservation_info"),
+        genericTerms=l.get_language_string("generic_terms"),
+        paymentTerms=l.get_language_string("payment_terms"),
+        specificTerms=l.get_language_string("specific_terms"),
+        responsibleContactInfo=l.get_language_string("responsible_contact_info"),
+        externalReservationUrl=respa_resource["external_reservation_url"],
+    )
+
+
+def get_unit_id_to_resources_mapping(
+    use_fallback_languages: bool,
+) -> Dict[str, List[Resource]]:
+    """
+    Get a mapping of unit IDs to their resources from Respa API.
+    """
+    result = defaultdict(list)
+    for respa_resource in get_respa_resources():
+        result[respa_resource.get("unit")].append(
+            create_exportable_resource(respa_resource, use_fallback_languages)
+        )
+    return result
+
+
 class LocationImporter(Importer[Root]):
     index_base_names = ("location",)
 
@@ -498,6 +611,9 @@ class LocationImporter(Importer[Root]):
 
         ontology = Ontology()
 
+        unit_id_to_resources_mapping = get_unit_id_to_resources_mapping(
+            self.use_fallback_languages
+        )
         accessibility_viewpoint_id_to_name_mapping = (
             get_accessibility_viewpoint_id_to_name_mapping(self.use_fallback_languages)
         )
@@ -566,6 +682,7 @@ class LocationImporter(Importer[Root]):
                     ).value,
                     name=l.get_language_string("displayed_service_owner"),
                 ),
+                resources=unit_id_to_resources_mapping.get(_id, []),
                 location=location,
                 meta=meta,
                 openingHours=opening_hours,

--- a/sources/ingest/importers/tests/test_resources.py
+++ b/sources/ingest/importers/tests/test_resources.py
@@ -1,0 +1,762 @@
+import pytest
+
+from ..location import (
+    get_unit_id_to_resources_mapping,
+    Resource,
+    ResourceType,
+    ResourceUserPermissions,
+)
+from ..utils import LanguageString
+
+MOCKED_RESPA_RESOURCE_RESPONSE = {
+    "count": 3,
+    "next": None,
+    "previous": None,
+    "results": [
+        {
+            "id": "axayciqmqfja",
+            "products": [
+                {
+                    "id": "axay4b73rdva",
+                    "type": "rent",
+                    "name": {"fi": "Tenniskenttä 2 - Ala-Malmi"},
+                    "description": {"fi": "Tenniskenttä 2 - Ala-Malmi"},
+                    "price": {
+                        "type": "per_period",
+                        "tax_percentage": "10.00",
+                        "amount": "7.30",
+                        "period": "01:00:00",
+                    },
+                    "max_quantity": 1,
+                }
+            ],
+            "purposes": [
+                {
+                    "name": {
+                        "fi": "Liikkua tai pelata",
+                        "en": "Sports or games",
+                        "sv": "Motionera eller spela",
+                    },
+                    "parent": None,
+                    "id": "sports",
+                }
+            ],
+            "images": [
+                {
+                    "url": "https://api.hel.fi/respa/resource_image/1181",
+                    "type": "other",
+                    "caption": None,
+                },
+                {
+                    "url": "https://api.hel.fi/respa/resource_image/1179",
+                    "type": "other",
+                    "caption": None,
+                },
+                {
+                    "url": "https://api.hel.fi/respa/resource_image/1178",
+                    "type": "main",
+                    "caption": None,
+                },
+                {
+                    "url": "https://api.hel.fi/respa/resource_image/1180",
+                    "type": "other",
+                    "caption": None,
+                },
+                {
+                    "url": "https://api.hel.fi/respa/resource_image/1204",
+                    "type": "ground_plan",
+                    "caption": None,
+                },
+            ],
+            "equipment": [],
+            "type": {
+                "name": {
+                    "fi": "Liikuntapaikka",
+                    "en": "Sports field",
+                    "sv": "Idrottsplats",
+                },
+                "main_type": "space",
+                "id": "awqjgibywfvq",
+            },
+            "opening_hours": [
+                {
+                    "date": "2023-07-26",
+                    "opens": "2023-07-26T08:00:00+03:00",
+                    "closes": "2023-07-26T21:00:00+03:00",
+                }
+            ],
+            "reservations": None,
+            "user_permissions": {
+                "can_make_reservations": True,
+                "can_ignore_opening_hours": False,
+                "is_admin": False,
+                "is_manager": False,
+                "is_viewer": False,
+                "can_bypass_payment": False,
+            },
+            "supported_reservation_extra_fields": [
+                "billing_email_address",
+                "billing_first_name",
+                "billing_last_name",
+                "billing_phone_number",
+                "participants",
+            ],
+            "required_reservation_extra_fields": [
+                "billing_email_address",
+                "billing_first_name",
+                "billing_last_name",
+            ],
+            "is_favorite": False,
+            "generic_terms": {"fi": "terms fi", "en": "terms en", "sv": "terms sv"},
+            "payment_terms": {
+                "fi": "payment_terms_fi",
+                "en": "payment_terms_en",
+                "sv": "payment_terms_sv",
+            },
+            "accessibility_base_url": "https://example.org/axayciqmqfja",
+            "reservable_days_in_advance": 14,
+            "reservable_max_days_in_advance": 14,
+            "reservable_before": "2023-08-10T00:00:00Z",
+            "reservable_min_days_in_advance": None,
+            "reservable_after": None,
+            "max_price_per_hour": 7.0,
+            "min_price_per_hour": 7.0,
+            "created_at": "2021-05-04T16:34:09.717587+03:00",
+            "modified_at": "2021-05-04T16:34:09.717606+03:00",
+            "public": True,
+            "name": {
+                "fi": "Tenniskenttä 2 - Ala-Malmi",
+                "en": "Tennis court 2 - Ala-Malmi",
+                "sv": "Tennisplan 2 - Nedre-Malm",
+            },
+            "description": {
+                "fi": "Varattavissa kaudelle 2023!",
+                "en": "Reservable for season 2023!",
+                "sv": "Bokningen för säsongen 2023 är öppen!",
+            },
+            "need_manual_confirmation": False,
+            "authentication": "weak",
+            "people_capacity": 4,
+            "area": 260,
+            "min_period": "00:30:00",
+            "max_period": "02:00:00",
+            "slot_size": "00:30:00",
+            "max_reservations_per_user": 2,
+            "reservable": True,
+            "reservation_info": {
+                "fi": "reservation_info_fi",
+                "en": "reservation_info_en",
+                "sv": "reservation_info_sv",
+            },
+            "responsible_contact_info": {
+                "fi": "responsible_contact_info_fi",
+                "en": "responsible_contact_info_en",
+                "sv": "responsible_contact_info_sv",
+            },
+            "specific_terms": {
+                "fi": "specific_terms_fi",
+                "en": "specific_terms_en",
+                "sv": "specific_terms_sv",
+            },
+            "min_price": "7.00",
+            "max_price": "7.00",
+            "price_type": "hourly",
+            "generate_access_codes": True,
+            "external_reservation_url": None,
+            "reservation_extra_questions": "",
+            "created_by": None,
+            "modified_by": None,
+            "unit": "tprek:42086",
+            "attachments": [],
+            "location": None,
+        },
+        {
+            "id": "axaxxck4ub7a",
+            "products": [
+                {
+                    "id": "axay4cnjl37a",
+                    "type": "rent",
+                    "name": {"fi": "Tenniskenttä 3 - Ala-Malmi"},
+                    "description": {"fi": "Tenniskenttä 3 - Ala-Malmi"},
+                    "price": {
+                        "type": "per_period",
+                        "tax_percentage": "10.00",
+                        "amount": "7.30",
+                        "period": "01:00:00",
+                    },
+                    "max_quantity": 1,
+                }
+            ],
+            "purposes": [
+                {
+                    "name": {
+                        "fi": "Liikkua tai pelata",
+                        "en": "Sports or games",
+                        "sv": "Motionera eller spela",
+                    },
+                    "parent": None,
+                    "id": "sports",
+                }
+            ],
+            "images": [
+                {
+                    "url": "https://api.hel.fi/respa/resource_image/1185",
+                    "type": "other",
+                    "caption": None,
+                },
+                {
+                    "url": "https://api.hel.fi/respa/resource_image/1183",
+                    "type": "other",
+                    "caption": None,
+                },
+                {
+                    "url": "https://api.hel.fi/respa/resource_image/1182",
+                    "type": "other",
+                    "caption": None,
+                },
+                {
+                    "url": "https://api.hel.fi/respa/resource_image/1184",
+                    "type": "main",
+                    "caption": None,
+                },
+                {
+                    "url": "https://api.hel.fi/respa/resource_image/1205",
+                    "type": "ground_plan",
+                    "caption": None,
+                },
+            ],
+            "equipment": [],
+            "type": {
+                "name": {
+                    "fi": "Liikuntapaikka",
+                    "en": "Sports field",
+                    "sv": "Idrottsplats",
+                },
+                "main_type": "space",
+                "id": "awqjgibywfvq",
+            },
+            "opening_hours": [
+                {
+                    "date": "2023-07-26",
+                    "opens": "2023-07-26T08:00:00+03:00",
+                    "closes": "2023-07-26T21:00:00+03:00",
+                }
+            ],
+            "reservations": None,
+            "user_permissions": {
+                "can_make_reservations": True,
+                "can_ignore_opening_hours": False,
+                "is_admin": False,
+                "is_manager": False,
+                "is_viewer": False,
+                "can_bypass_payment": False,
+            },
+            "supported_reservation_extra_fields": [
+                "billing_email_address",
+                "billing_first_name",
+                "billing_last_name",
+                "billing_phone_number",
+                "participants",
+            ],
+            "required_reservation_extra_fields": [
+                "billing_email_address",
+                "billing_first_name",
+                "billing_last_name",
+            ],
+            "is_favorite": False,
+            "generic_terms": {
+                "fi": "generic_terms_fi",
+                "en": "generic_terms_en",
+                "sv": "generic_terms_sv",
+            },
+            "payment_terms": {
+                "fi": "payment_terms_fi",
+                "en": "payment_terms_en",
+                "sv": "payment_terms_sv",
+            },
+            "accessibility_base_url": "https://example.org/axaxxck4ub7a",
+            "reservable_days_in_advance": 14,
+            "reservable_max_days_in_advance": 14,
+            "reservable_before": "2023-08-10T00:00:00Z",
+            "reservable_min_days_in_advance": None,
+            "reservable_after": None,
+            "max_price_per_hour": 7.0,
+            "min_price_per_hour": 7.0,
+            "created_at": "2021-05-04T09:53:33.217020+03:00",
+            "modified_at": "2021-05-04T09:53:33.217040+03:00",
+            "public": True,
+            "name": {
+                "fi": "Tenniskenttä 3 - Ala-Malmi",
+                "en": "Tennis court 3 - Ala-Malmi",
+                "sv": "Tennisplan 3 - Nedre-Malm",
+            },
+            "description": {
+                "fi": "description_fi",
+                "en": "description_en",
+                "sv": "description_sv",
+            },
+            "need_manual_confirmation": False,
+            "authentication": "weak",
+            "people_capacity": 4,
+            "area": None,
+            "min_period": "00:30:00",
+            "max_period": "02:00:00",
+            "slot_size": "00:30:00",
+            "max_reservations_per_user": 2,
+            "reservable": True,
+            "reservation_info": {
+                "fi": "reservation_info_fi",
+                "en": "reservation_info_en",
+                "sv": "reservation_info_sv",
+            },
+            "responsible_contact_info": {
+                "fi": "responsible_contact_info_fi",
+                "en": "responsible_contact_info_en",
+                "sv": "responsible_contact_info_sv",
+            },
+            "specific_terms": {
+                "fi": "specific_terms_fi",
+                "en": "specific_terms_en",
+                "sv": "specific_terms_sv",
+            },
+            "min_price": "7.00",
+            "max_price": "7.00",
+            "price_type": "hourly",
+            "generate_access_codes": True,
+            "external_reservation_url": None,
+            "reservation_extra_questions": "",
+            "created_by": None,
+            "modified_by": None,
+            "unit": "tprek:42086",
+            "attachments": [],
+            "location": None,
+        },
+        {
+            "id": "aweyzvgot72q",
+            "products": [],
+            "purposes": [
+                {
+                    "name": {
+                        "fi": "Järjestää tapahtuman",
+                        "en": "Organize event",
+                        "sv": "Arrangera evenemanget",
+                    },
+                    "parent": None,
+                    "id": "events",
+                }
+            ],
+            "images": [
+                {
+                    "url": "https://api.hel.fi/respa/resource_image/1175",
+                    "type": "main",
+                    "caption": None,
+                },
+                {
+                    "url": "https://api.hel.fi/respa/resource_image/1176",
+                    "type": "other",
+                    "caption": None,
+                },
+                {
+                    "url": "https://api.hel.fi/respa/resource_image/641",
+                    "type": "map",
+                    "caption": None,
+                },
+                {
+                    "url": "https://api.hel.fi/respa/resource_image/1177",
+                    "type": "other",
+                    "caption": None,
+                },
+            ],
+            "equipment": [],
+            "type": {
+                "name": {
+                    "fi": "Tapahtumatila",
+                    "en": "Event space",
+                    "sv": "Evenemangsutrymme",
+                },
+                "main_type": "space",
+                "id": "event_space",
+            },
+            "opening_hours": [{"date": "2023-07-26", "opens": None, "closes": None}],
+            "reservations": None,
+            "user_permissions": {
+                "can_make_reservations": True,
+                "can_ignore_opening_hours": False,
+                "is_admin": False,
+                "is_manager": False,
+                "is_viewer": False,
+                "can_bypass_payment": False,
+            },
+            "supported_reservation_extra_fields": [
+                "reserver_name",
+                "reserver_phone_number",
+                "event_description",
+                "number_of_participants",
+                "reserver_email_address",
+                "event_subject",
+            ],
+            "required_reservation_extra_fields": [
+                "reserver_name",
+                "reserver_phone_number",
+                "event_description",
+                "number_of_participants",
+                "reserver_email_address",
+                "event_subject",
+            ],
+            "is_favorite": False,
+            "generic_terms": {"fi": "info fi", "en": "info en", "sv": "info sv"},
+            "payment_terms": "",
+            "accessibility_base_url": "https://example.org/aweyzvgot72q",
+            "reservable_days_in_advance": None,
+            "reservable_max_days_in_advance": None,
+            "reservable_before": None,
+            "reservable_min_days_in_advance": None,
+            "reservable_after": None,
+            "max_price_per_hour": None,
+            "min_price_per_hour": None,
+            "created_at": "2019-05-23T15:00:42.247090+03:00",
+            "modified_at": "2019-05-23T15:00:42.247111+03:00",
+            "public": True,
+            "name": {
+                "fi": "Ala-Malmin puisto",
+                "en": "Ala-Malmin puisto park",
+                "sv": "Nedre Malms park",
+            },
+            "description": {"fi": "test fi", "en": "test en", "sv": "test sv"},
+            "need_manual_confirmation": False,
+            "authentication": "strong",
+            "people_capacity": 200,
+            "area": 1000,
+            "min_period": "01:00:00",
+            "max_period": "10:00:00",
+            "slot_size": "01:00:00",
+            "max_reservations_per_user": 11,
+            "reservable": True,
+            "reservation_info": None,
+            "responsible_contact_info": {"fi": "Yhteissähköposti: ulkoilma@hel.fi"},
+            "specific_terms": {"fi": "testi"},
+            "min_price": None,
+            "max_price": None,
+            "price_type": "hourly",
+            "generate_access_codes": True,
+            "external_reservation_url": "https://tilavaraus.hel.fi/reservation-unit/479",
+            "reservation_extra_questions": "",
+            "created_by": None,
+            "modified_by": 10043,
+            "unit": "tprek:59763",
+            "attachments": [],
+            "location": None,
+        },
+    ],
+}
+
+
+@pytest.fixture(scope="module", autouse=True)
+def mocked_respa_resource_response(module_mocker):
+    return module_mocker.patch(
+        "ingest.importers.location.request_json",
+        return_value=MOCKED_RESPA_RESOURCE_RESPONSE,
+    )
+
+
+@pytest.mark.parametrize(
+    "use_fallback_languages,expected_result",
+    [
+        (
+            False,
+            {
+                "tprek:42086": [
+                    Resource(
+                        id="axayciqmqfja",
+                        name=LanguageString(
+                            fi="Tenniskenttä 2 - Ala-Malmi",
+                            sv="Tennisplan 2 - Nedre-Malm",
+                            en="Tennis court 2 - Ala-Malmi",
+                        ),
+                        description=LanguageString(
+                            fi="Varattavissa kaudelle 2023!",
+                            sv="Bokningen för säsongen 2023 är öppen!",
+                            en="Reservable for season 2023!",
+                        ),
+                        type=ResourceType(
+                            id="awqjgibywfvq",
+                            mainType="space",
+                            name=LanguageString(
+                                fi="Liikuntapaikka",
+                                sv="Idrottsplats",
+                                en="Sports field",
+                            ),
+                        ),
+                        userPermissions=ResourceUserPermissions(
+                            canMakeReservations=True
+                        ),
+                        reservable=True,
+                        reservationInfo=LanguageString(
+                            fi="reservation_info_fi",
+                            sv="reservation_info_sv",
+                            en="reservation_info_en",
+                        ),
+                        genericTerms=LanguageString(
+                            fi="terms fi", sv="terms sv", en="terms en"
+                        ),
+                        paymentTerms=LanguageString(
+                            fi="payment_terms_fi",
+                            sv="payment_terms_sv",
+                            en="payment_terms_en",
+                        ),
+                        specificTerms=LanguageString(
+                            fi="specific_terms_fi",
+                            sv="specific_terms_sv",
+                            en="specific_terms_en",
+                        ),
+                        responsibleContactInfo=LanguageString(
+                            fi="responsible_contact_info_fi",
+                            sv="responsible_contact_info_sv",
+                            en="responsible_contact_info_en",
+                        ),
+                        externalReservationUrl=None,
+                    ),
+                    Resource(
+                        id="axaxxck4ub7a",
+                        name=LanguageString(
+                            fi="Tenniskenttä 3 - Ala-Malmi",
+                            sv="Tennisplan 3 - Nedre-Malm",
+                            en="Tennis court 3 - Ala-Malmi",
+                        ),
+                        description=LanguageString(
+                            fi="description_fi",
+                            sv="description_sv",
+                            en="description_en",
+                        ),
+                        type=ResourceType(
+                            id="awqjgibywfvq",
+                            mainType="space",
+                            name=LanguageString(
+                                fi="Liikuntapaikka",
+                                sv="Idrottsplats",
+                                en="Sports field",
+                            ),
+                        ),
+                        userPermissions=ResourceUserPermissions(
+                            canMakeReservations=True
+                        ),
+                        reservable=True,
+                        reservationInfo=LanguageString(
+                            fi="reservation_info_fi",
+                            sv="reservation_info_sv",
+                            en="reservation_info_en",
+                        ),
+                        genericTerms=LanguageString(
+                            fi="generic_terms_fi",
+                            sv="generic_terms_sv",
+                            en="generic_terms_en",
+                        ),
+                        paymentTerms=LanguageString(
+                            fi="payment_terms_fi",
+                            sv="payment_terms_sv",
+                            en="payment_terms_en",
+                        ),
+                        specificTerms=LanguageString(
+                            fi="specific_terms_fi",
+                            sv="specific_terms_sv",
+                            en="specific_terms_en",
+                        ),
+                        responsibleContactInfo=LanguageString(
+                            fi="responsible_contact_info_fi",
+                            sv="responsible_contact_info_sv",
+                            en="responsible_contact_info_en",
+                        ),
+                        externalReservationUrl=None,
+                    ),
+                ],
+                "tprek:59763": [
+                    Resource(
+                        id="aweyzvgot72q",
+                        name=LanguageString(
+                            fi="Ala-Malmin puisto",
+                            sv="Nedre Malms park",
+                            en="Ala-Malmin puisto park",
+                        ),
+                        description=LanguageString(
+                            fi="test fi", sv="test sv", en="test en"
+                        ),
+                        type=ResourceType(
+                            id="event_space",
+                            mainType="space",
+                            name=LanguageString(
+                                fi="Tapahtumatila",
+                                sv="Evenemangsutrymme",
+                                en="Event space",
+                            ),
+                        ),
+                        userPermissions=ResourceUserPermissions(
+                            canMakeReservations=True
+                        ),
+                        reservable=True,
+                        reservationInfo=None,
+                        genericTerms=LanguageString(
+                            fi="info fi", sv="info sv", en="info en"
+                        ),
+                        paymentTerms=None,
+                        specificTerms=LanguageString(fi="testi", sv=None, en=None),
+                        responsibleContactInfo=LanguageString(
+                            fi="Yhteissähköposti: ulkoilma@hel.fi", sv=None, en=None
+                        ),
+                        externalReservationUrl="https://tilavaraus.hel.fi/reservation-unit/479",
+                    )
+                ],
+            },
+        ),
+        (
+            True,
+            {
+                "tprek:42086": [
+                    Resource(
+                        id="axayciqmqfja",
+                        name=LanguageString(
+                            fi="Tenniskenttä 2 - Ala-Malmi",
+                            sv="Tennisplan 2 - Nedre-Malm",
+                            en="Tennis court 2 - Ala-Malmi",
+                        ),
+                        description=LanguageString(
+                            fi="Varattavissa kaudelle 2023!",
+                            sv="Bokningen för säsongen 2023 är öppen!",
+                            en="Reservable for season 2023!",
+                        ),
+                        type=ResourceType(
+                            id="awqjgibywfvq",
+                            mainType="space",
+                            name=LanguageString(
+                                fi="Liikuntapaikka",
+                                sv="Idrottsplats",
+                                en="Sports field",
+                            ),
+                        ),
+                        userPermissions=ResourceUserPermissions(
+                            canMakeReservations=True
+                        ),
+                        reservable=True,
+                        reservationInfo=LanguageString(
+                            fi="reservation_info_fi",
+                            sv="reservation_info_sv",
+                            en="reservation_info_en",
+                        ),
+                        genericTerms=LanguageString(
+                            fi="terms fi", sv="terms sv", en="terms en"
+                        ),
+                        paymentTerms=LanguageString(
+                            fi="payment_terms_fi",
+                            sv="payment_terms_sv",
+                            en="payment_terms_en",
+                        ),
+                        specificTerms=LanguageString(
+                            fi="specific_terms_fi",
+                            sv="specific_terms_sv",
+                            en="specific_terms_en",
+                        ),
+                        responsibleContactInfo=LanguageString(
+                            fi="responsible_contact_info_fi",
+                            sv="responsible_contact_info_sv",
+                            en="responsible_contact_info_en",
+                        ),
+                        externalReservationUrl=None,
+                    ),
+                    Resource(
+                        id="axaxxck4ub7a",
+                        name=LanguageString(
+                            fi="Tenniskenttä 3 - Ala-Malmi",
+                            sv="Tennisplan 3 - Nedre-Malm",
+                            en="Tennis court 3 - Ala-Malmi",
+                        ),
+                        description=LanguageString(
+                            fi="description_fi",
+                            sv="description_sv",
+                            en="description_en",
+                        ),
+                        type=ResourceType(
+                            id="awqjgibywfvq",
+                            mainType="space",
+                            name=LanguageString(
+                                fi="Liikuntapaikka",
+                                sv="Idrottsplats",
+                                en="Sports field",
+                            ),
+                        ),
+                        userPermissions=ResourceUserPermissions(
+                            canMakeReservations=True
+                        ),
+                        reservable=True,
+                        reservationInfo=LanguageString(
+                            fi="reservation_info_fi",
+                            sv="reservation_info_sv",
+                            en="reservation_info_en",
+                        ),
+                        genericTerms=LanguageString(
+                            fi="generic_terms_fi",
+                            sv="generic_terms_sv",
+                            en="generic_terms_en",
+                        ),
+                        paymentTerms=LanguageString(
+                            fi="payment_terms_fi",
+                            sv="payment_terms_sv",
+                            en="payment_terms_en",
+                        ),
+                        specificTerms=LanguageString(
+                            fi="specific_terms_fi",
+                            sv="specific_terms_sv",
+                            en="specific_terms_en",
+                        ),
+                        responsibleContactInfo=LanguageString(
+                            fi="responsible_contact_info_fi",
+                            sv="responsible_contact_info_sv",
+                            en="responsible_contact_info_en",
+                        ),
+                        externalReservationUrl=None,
+                    ),
+                ],
+                "tprek:59763": [
+                    Resource(
+                        id="aweyzvgot72q",
+                        name=LanguageString(
+                            fi="Ala-Malmin puisto",
+                            sv="Nedre Malms park",
+                            en="Ala-Malmin puisto park",
+                        ),
+                        description=LanguageString(
+                            fi="test fi", sv="test sv", en="test en"
+                        ),
+                        type=ResourceType(
+                            id="event_space",
+                            mainType="space",
+                            name=LanguageString(
+                                fi="Tapahtumatila",
+                                sv="Evenemangsutrymme",
+                                en="Event space",
+                            ),
+                        ),
+                        userPermissions=ResourceUserPermissions(
+                            canMakeReservations=True
+                        ),
+                        reservable=True,
+                        reservationInfo=None,
+                        genericTerms=LanguageString(
+                            fi="info fi", sv="info sv", en="info en"
+                        ),
+                        paymentTerms=None,
+                        specificTerms=LanguageString(
+                            fi="testi", sv="testi", en="testi"
+                        ),
+                        responsibleContactInfo=LanguageString(
+                            fi="Yhteissähköposti: ulkoilma@hel.fi",
+                            sv="Yhteissähköposti: ulkoilma@hel.fi",
+                            en="Yhteissähköposti: ulkoilma@hel.fi",
+                        ),
+                        externalReservationUrl="https://tilavaraus.hel.fi/reservation-unit/479",
+                    )
+                ],
+            },
+        ),
+    ],
+)
+def test_get_unit_id_to_resources_mapping(use_fallback_languages, expected_result):
+    assert get_unit_id_to_resources_mapping(use_fallback_languages) == expected_result

--- a/sources/ingest/importers/utils/traffic.py
+++ b/sources/ingest/importers/utils/traffic.py
@@ -4,14 +4,12 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-TIMEOUT = 20
 
-
-def request_json(url):
+def request_json(url, timeout_seconds=20):
     logger.debug(f"Requesting URL {url}")
     result = None
     try:
-        r = requests.get(url, timeout=TIMEOUT)
+        r = requests.get(url, timeout=timeout_seconds)
         r.raise_for_status()
         result = r.json()
     except Exception as e:


### PR DESCRIPTION
## Description

### feat: import venues' Respa API resources, e.g. reservability

`python manage.py ingest_data location` will now import venues' related
resources from Respa API:
 - List of resources each containing:
   - id
   - name
   - type
	 - id
	 - main type (item, person or space)
	 - name
   - user permissions
	 - can make reservations?
   - reservable? (through the Respa API)
   - reservation info
   - generic terms
   - payment terms
   - specific terms
   - responsible contact info
   - external reservation URL

refs US-108

## Tickets

- [US-108](https://helsinkisolutionoffice.atlassian.net/browse/US-108)

## Manual testing

- For testing purposes disregard expired certificate of geoserver.hel.fi so testing is possible (→[PT-4958](https://helsinkisolutionoffice.atlassian.net/browse/PLATTA-4985))
  - `cp .env.example .env`
  - `echo "GDAL_HTTP_UNSAFESSL=YES" >> .env`
- checkout the main branch version
  - `docker-compose up --build`
  - `docker exec -it unified-search_sources_1 bash`
    - `python manage.py ingest_data location --use-fallback-languages`
    - Open http://localhost:5601/app/dev_tools#/console and fetch all data [1] (Seems paginated so actually partial) , save as `before.json`
- checkout this PR's branch's version
  - `docker-compose up --build`
  - `docker exec -it unified-search_sources_1 bash`- 
    - `python manage.py ingest_data location --use-fallback-languages`
    - Open http://localhost:5601/app/dev_tools#/console and fetch all data [1] (Seems paginated so actually partial), save as `after.json`
- `diff ./before.json ./after.json > change.diff` → [2]

[1] fetch all data:
```
GET _search
{
  "query": {
    "match_all": {}
  }
}
```

<details>
  <summary>[2] change.diff:</summary>

```diff
TODO
```

</details>