### PR TITLE
US-103 | import venues' accessibility shortages and sentences

### DIFF
--- a/graphql/src/schemas/location.ts
+++ b/graphql/src/schemas/location.ts
@@ -94,11 +94,17 @@ export const locationSchema = gql`
     profile: AccessibilityProfile
     count: Int
   }
+  type AccessibilitySentence {
+    sentenceGroupName: String
+    sentenceGroup: LanguageString
+    sentence: LanguageString
+  }
   type Accessibility {
     email: String
     phone: String
     www: String
     viewpoints: [AccessibilityViewpoint]
+    sentences: [AccessibilitySentence]
     shortcomings: [AccessibilityShortcoming]
   }
   enum ResourceMainType {

--- a/graphql/src/schemas/location.ts
+++ b/graphql/src/schemas/location.ts
@@ -81,6 +81,7 @@ export const locationSchema = gql`
     id: ID
     name: LanguageString
     value: AccessibilityViewpointValue
+    shortages: [LanguageString]
   }
   enum AccessibilityProfile {
     hearing_aid

--- a/sources/ingest/importers/tests/test_accessibility_sentences.py
+++ b/sources/ingest/importers/tests/test_accessibility_sentences.py
@@ -1,0 +1,154 @@
+import pytest
+
+from ..location import (
+    AccessibilitySentence,
+    get_unit_id_to_accessibility_sentences_mapping,
+)
+from ..utils import LanguageString
+
+MOCKED_SERVICE_MAP_ACCESSIBILITY_SENTENCE_VIEWPOINT_RESPONSE = [
+    {
+        "unit_id": 6365,
+        "sentence_group_name": "Kulkureitti pääsisäänkäynnille",
+        "sentence_group_fi": "Reitti pääsisäänkäynnille",
+        "sentence_group_sv": "Rutten till huvudingången",
+        "sentence_group_en": "The route to the main entrance",
+        "sentence_fi": "Kulkureitti sisäänkäynnille on tasainen ja riittävän leveä sekä valaistu.",
+        "sentence_sv": "Rutten till ingången är jämn och tillräckligt bred samt belyst.",
+        "sentence_en": "The route to the entrance is smooth and sufficiently wide and illuminated.",
+    },
+    {
+        "unit_id": 6365,
+        "sentence_group_name": "Pääsisäänkäynti",
+        "sentence_group_fi": "Pääsisäänkäynti",
+        "sentence_group_sv": "Huvudingången",
+        "sentence_group_en": "The main entrance",
+        "sentence_fi": "Sisäänkäynti sijaitsee syvennyksessä ja on valaistu.",
+        "sentence_sv": "Ingången är belägen i en nisch och belyst.",
+        "sentence_en": "The entrance is located in a recess and is illuminated.",
+    },
+    {
+        "unit_id": 1414,
+        "sentence_group_name": "Sisätilat",
+        "sentence_group_fi": "Sisätilat",
+        "sentence_group_sv": "I lokalen",
+        "sentence_fi": "Toimipisteessä on esteetön wc.",
+        "sentence_sv": "I verksamhetslokalen finns en tillgänglig toalett.",
+    },
+]
+
+
+@pytest.fixture
+def mocked_service_map_accessibility_sentence_viewpoint_response(mocker):
+    return mocker.patch(
+        "ingest.importers.location.request_json",
+        return_value=MOCKED_SERVICE_MAP_ACCESSIBILITY_SENTENCE_VIEWPOINT_RESPONSE,
+    )
+
+
+@pytest.mark.parametrize(
+    "use_fallback_languages,expected_result",
+    [
+        (
+            False,
+            {
+                "1414": [
+                    AccessibilitySentence(
+                        sentenceGroupName="Sisätilat",
+                        sentenceGroup=LanguageString(
+                            fi="Sisätilat", sv="I lokalen", en=None
+                        ),
+                        sentence=LanguageString(
+                            fi="Toimipisteessä on esteetön wc.",
+                            sv="I verksamhetslokalen finns en tillgänglig toalett.",
+                            en=None,
+                        ),
+                    )
+                ],
+                "6365": [
+                    AccessibilitySentence(
+                        sentenceGroupName="Kulkureitti pääsisäänkäynnille",
+                        sentenceGroup=LanguageString(
+                            fi="Reitti pääsisäänkäynnille",
+                            sv="Rutten till huvudingången",
+                            en="The route to the main entrance",
+                        ),
+                        sentence=LanguageString(
+                            fi="Kulkureitti sisäänkäynnille on tasainen ja riittävän leveä sekä valaistu.",
+                            sv="Rutten till ingången är jämn och tillräckligt bred samt belyst.",
+                            en="The route to the entrance is smooth and sufficiently wide and illuminated.",
+                        ),
+                    ),
+                    AccessibilitySentence(
+                        sentenceGroupName="Pääsisäänkäynti",
+                        sentenceGroup=LanguageString(
+                            fi="Pääsisäänkäynti",
+                            sv="Huvudingången",
+                            en="The main entrance",
+                        ),
+                        sentence=LanguageString(
+                            fi="Sisäänkäynti sijaitsee syvennyksessä ja on valaistu.",
+                            sv="Ingången är belägen i en nisch och belyst.",
+                            en="The entrance is located in a recess and is illuminated.",
+                        ),
+                    ),
+                ],
+            },
+        ),
+        (
+            True,
+            {
+                "1414": [
+                    AccessibilitySentence(
+                        sentenceGroupName="Sisätilat",
+                        sentenceGroup=LanguageString(
+                            fi="Sisätilat", sv="I lokalen", en="Sisätilat"
+                        ),
+                        sentence=LanguageString(
+                            fi="Toimipisteessä on esteetön wc.",
+                            sv="I verksamhetslokalen finns en tillgänglig toalett.",
+                            en="Toimipisteessä on esteetön wc.",
+                        ),
+                    )
+                ],
+                "6365": [
+                    AccessibilitySentence(
+                        sentenceGroupName="Kulkureitti pääsisäänkäynnille",
+                        sentenceGroup=LanguageString(
+                            fi="Reitti pääsisäänkäynnille",
+                            sv="Rutten till huvudingången",
+                            en="The route to the main entrance",
+                        ),
+                        sentence=LanguageString(
+                            fi="Kulkureitti sisäänkäynnille on tasainen ja riittävän leveä sekä valaistu.",
+                            sv="Rutten till ingången är jämn och tillräckligt bred samt belyst.",
+                            en="The route to the entrance is smooth and sufficiently wide and illuminated.",
+                        ),
+                    ),
+                    AccessibilitySentence(
+                        sentenceGroupName="Pääsisäänkäynti",
+                        sentenceGroup=LanguageString(
+                            fi="Pääsisäänkäynti",
+                            sv="Huvudingången",
+                            en="The main entrance",
+                        ),
+                        sentence=LanguageString(
+                            fi="Sisäänkäynti sijaitsee syvennyksessä ja on valaistu.",
+                            sv="Ingången är belägen i en nisch och belyst.",
+                            en="The entrance is located in a recess and is illuminated.",
+                        ),
+                    ),
+                ],
+            },
+        ),
+    ],
+)
+def test_get_unit_id_to_accessibility_shortcomings_mapping(
+    mocked_service_map_accessibility_sentence_viewpoint_response,
+    use_fallback_languages,
+    expected_result,
+):
+    assert (
+        get_unit_id_to_accessibility_sentences_mapping(use_fallback_languages)
+        == expected_result
+    )

--- a/sources/ingest/importers/tests/test_accessibility_shortages.py
+++ b/sources/ingest/importers/tests/test_accessibility_shortages.py
@@ -1,0 +1,157 @@
+import pytest
+
+from ..location import (
+    Accessibility,
+    AccessibilityViewpoint,
+    get_unit_id_to_accessibility_viewpoint_shortages_mapping,
+)
+from ..utils import LanguageString
+
+MOCKED_SERVICE_MAP_ACCESSIBILITY_SHORTAGE_VIEWPOINT_RESPONSE = [
+    {
+        "unit_id": 2,
+        "viewpoint_id": "32",
+        "shortage_fi": "Esteettömiä autopaikkoja ei ole.",
+        "shortage_sv": "Inga p-platser för personer med rörelsehinder.",
+        "shortage_en": "No parking places for persons with a disability.",
+    },
+    {
+        "unit_id": 2,
+        "viewpoint_id": "32",
+        "shortage_fi": "Sisäänkäynnissä on ahdas tuulikaappi.",
+        "shortage_sv": "Det finns ett trångt vindfång vid ingången.",
+        "shortage_en": "The entrance has a cramped foyer.",
+    },
+    {
+        "unit_id": 2,
+        "viewpoint_id": "21",
+        "shortage_fi": "Ei puutteita.",
+        "shortage_sv": "Inga brister.",
+        "shortage_en": "No shortcomings.",
+    },
+    {
+        "unit_id": 16,
+        "viewpoint_id": "33",
+        "shortage_fi": "Toimipisteessä ei ole esteetöntä wc:tä.",
+        "shortage_sv": "Det finns ingen tillgänglig toalett i verksamhetsstället.",
+        "shortage_en": "The facility does not have an accessible toilet.",
+    },
+]
+
+
+@pytest.fixture
+def mocked_service_map_accessibility_shortage_viewpoint_response(mocker):
+    return mocker.patch(
+        "ingest.importers.location.request_json",
+        return_value=MOCKED_SERVICE_MAP_ACCESSIBILITY_SHORTAGE_VIEWPOINT_RESPONSE,
+    )
+
+
+def test_get_unit_id_to_accessibility_shortcomings_mapping(
+    mocked_service_map_accessibility_shortage_viewpoint_response,
+):
+    assert get_unit_id_to_accessibility_viewpoint_shortages_mapping(
+        use_fallback_languages=False
+    ) == {
+        "16": {
+            "33": [
+                LanguageString(
+                    fi="Toimipisteessä ei ole esteetöntä wc:tä.",
+                    sv="Det finns ingen tillgänglig toalett i verksamhetsstället.",
+                    en="The facility does not have an accessible toilet.",
+                )
+            ]
+        },
+        "2": {
+            "21": [
+                LanguageString(
+                    fi="Ei puutteita.", sv="Inga brister.", en="No shortcomings."
+                )
+            ],
+            "32": [
+                LanguageString(
+                    fi="Esteettömiä autopaikkoja ei ole.",
+                    sv="Inga p-platser för personer med rörelsehinder.",
+                    en="No parking places for persons with a disability.",
+                ),
+                LanguageString(
+                    fi="Sisäänkäynnissä on ahdas tuulikaappi.",
+                    sv="Det finns ett trångt vindfång vid ingången.",
+                    en="The entrance has a cramped foyer.",
+                ),
+            ],
+        },
+    }
+
+
+def test_set_accessibility_shortages(
+    mocked_service_map_accessibility_shortage_viewpoint_response,
+):
+    accessibility = Accessibility(
+        email="",
+        phone="",
+        www="",
+        viewpoints=[
+            AccessibilityViewpoint(
+                id="21",
+                name=LanguageString(
+                    fi="Olen liikkumisesteinen, mutta kävelen",
+                    sv="Jag är rörelsehindrad, men jag går",
+                    en="I have reduced mobility, but I walk",
+                ),
+                value="green",
+            ),
+            AccessibilityViewpoint(
+                id="32",
+                name=LanguageString(
+                    fi="Olen rollaattorin käyttäjä - saavun omalla autolla",
+                    sv="Jag är en rollatoranvändare - kommer med min egen bil",
+                    en="I am a rollator user - arrive by my car",
+                ),
+                value="red",
+            ),
+        ],
+        sentences=[],
+        shortcomings=[],
+    )
+    viewpoint_id_to_shortages = {
+        "21": [
+            LanguageString(
+                fi="Ei puutteita.", sv="Inga brister.", en="No shortcomings."
+            )
+        ],
+        "32": [
+            LanguageString(
+                fi="Esteettömiä autopaikkoja ei ole.",
+                sv="Inga p-platser för personer med rörelsehinder.",
+                en="No parking places for persons with a disability.",
+            ),
+            LanguageString(
+                fi="Sisäänkäynnissä on ahdas tuulikaappi.",
+                sv="Det finns ett trångt vindfång vid ingången.",
+                en="The entrance has a cramped foyer.",
+            ),
+        ],
+    }
+    accessibility.set_accessibility_shortages(viewpoint_id_to_shortages)
+    assert accessibility.viewpoints[0].shortages == [
+        LanguageString(fi="Ei puutteita.", sv="Inga brister.", en="No shortcomings.")
+    ]
+    assert accessibility.viewpoints[1].shortages == [
+        LanguageString(
+            fi="Esteettömiä autopaikkoja ei ole.",
+            sv="Inga p-platser för personer med rörelsehinder.",
+            en="No parking places for persons with a disability.",
+        ),
+        LanguageString(
+            fi="Sisäänkäynnissä on ahdas tuulikaappi.",
+            sv="Det finns ett trångt vindfång vid ingången.",
+            en="The entrance has a cramped foyer.",
+        ),
+    ]
+    accessibility.set_accessibility_shortages({})
+    assert all(not viewpoint.shortages for viewpoint in accessibility.viewpoints)
+    accessibility.set_accessibility_shortages(
+        {"inexistent_viewpoint_id": [LanguageString(fi="Test", sv="Test", en="Test")]}
+    )
+    assert all(not viewpoint.shortages for viewpoint in accessibility.viewpoints)


### PR DESCRIPTION
## Description

### feat: import venues' accessibility shortages per accessibility viewpoint

`python manage.py ingest_data location` will now import venues'
accessibility shortages per viewpoint:
 - List of accessibility shortages (fi/sv/en) for each accessibility
   viewpoint, e.g.
   - Viewpoint "I am a rollator user - arrive by my car" (id="32"):
	 - Shortages (With translations into Finnish and Swedish):
	   - "No parking places for persons with a disability."
	   - "The entrance has a cramped foyer."

refs US-103

### feat: import venues' accessibility sentences

`python manage.py ingest_data location` will now import venues'
accessibility sentences:
 - List of accessibility sentences each containing:
   - sentence group name
   - sentence group (fi/sv/en)
   - sentence (fi/sv/en)

refs US-103

## Tickets

- [US-103](https://helsinkisolutionoffice.atlassian.net/browse/US-103)

## Manual testing

- checkout this PR's branch's version
  - `cp .env.example .env`
  - `docker-compose up --build`
  - `docker exec -it unified-search_sources_1 bash`- 
    - `python manage.py ingest_data location --use-fallback-languages`
    - Open http://localhost:5601/app/dev_tools#/console and fetch data [1]

[1] fetch data:
```
GET _search
{
  "query": {
    "match_all": {}
  }
}
```

## Example data of a single venue

Source data:
 - unit ID = 2
   - https://api.hel.fi/servicemap/v2/unit/2/
   - https://www.hel.fi/palvelukarttaws/rest/v4/unit/2

### Accessibility part of a single venue queried with the above [1] query:

NOTE: The new imported data are under the "shortages" and "sentences" keys.
```json
{
  "accessibility": {
    "email": "pk.kannelmaki@hel.fi",
    "phone": "+358 9 310 41596",
    "www": "https://asiointi.hel.fi/kapaesteettomyys/app/summary/tpr:230/",
    "viewpoints": [
      {
        "id": "11",
        "name": {
          "fi": "Olen pyörätuolin käyttäjä",
          "sv": "Jag är en rullstolsanvändare",
          "en": "I am a wheelchair user"
        },
        "value": "red",
        "shortages": [
          {
            "fi": "Sisäänkäynnissä on ahdas tuulikaappi.",
            "sv": "Det finns ett trångt vindfång vid ingången.",
            "en": "The entrance has a cramped foyer."
          }
        ]
      },
      {
        "id": "12",
        "name": {
          "fi": "Olen pyörätuolin käyttäjä - saavun omalla autolla",
          "sv": "Jag är en rullstolsanvändare - kommer med min egen bil",
          "en": "I am a wheelchair user - arrive by my car"
        },
        "value": "red",
        "shortages": [
          {
            "fi": "Esteettömiä autopaikkoja ei ole.",
            "sv": "Inga p-platser för personer med rörelsehinder.",
            "en": "No parking places for persons with a disability."
          },
          {
            "fi": "Sisäänkäynnissä on ahdas tuulikaappi.",
            "sv": "Det finns ett trångt vindfång vid ingången.",
            "en": "The entrance has a cramped foyer."
          }
        ]
      },
      {
        "id": "13",
        "name": {
          "fi": "Olen pyörätuolin käyttäjä - saavun saattoliikenteellä",
          "sv": "Jag är en rullstolsanvändare - kommer med angöringstrafik",
          "en": "I am a wheelchair user - arrive with pick-up and drop-off traffic"
        },
        "value": "red",
        "shortages": [
          {
            "fi": "Sisäänkäynnissä on ahdas tuulikaappi.",
            "sv": "Det finns ett trångt vindfång vid ingången.",
            "en": "The entrance has a cramped foyer."
          }
        ]
      },
      {
        "id": "21",
        "name": {
          "fi": "Olen liikkumisesteinen, mutta kävelen",
          "sv": "Jag är rörelsehindrad, men jag går",
          "en": "I have reduced mobility, but I walk"
        },
        "value": "green",
        "shortages": [
          {
            "fi": "Ei puutteita.",
            "sv": "Inga brister.",
            "en": "No shortcomings."
          }
        ]
      },
      {
        "id": "22",
        "name": {
          "fi": "Olen liikkumisesteinen, mutta kävelen - saavun omalla autolla",
          "sv": "Jag är rörelsehindrad, men jag går - kommer med min egen bil",
          "en": "I have reduced mobility, but I walk - arrive by my car"
        },
        "value": "red",
        "shortages": [
          {
            "fi": "Esteettömiä autopaikkoja ei ole.",
            "sv": "Inga p-platser för personer med rörelsehinder.",
            "en": "No parking places for persons with a disability."
          }
        ]
      },
      {
        "id": "23",
        "name": {
          "fi": "Olen liikkumisesteinen, mutta kävelen - saavun saattoliikenteellä",
          "sv": "Jag är rörelsehindrad, men jag går - kommer med angöringstrafik",
          "en": "I have reduced mobility, but I walk - arrive with pick-up and drop-off traffic"
        },
        "value": "green",
        "shortages": [
          {
            "fi": "Ei puutteita.",
            "sv": "Inga brister.",
            "en": "No shortcomings."
          }
        ]
      },
      {
        "id": "31",
        "name": {
          "fi": "Olen rollaattorin käyttäjä",
          "sv": "Jag är en rollatoranvändare",
          "en": "I am a rollator user"
        },
        "value": "red",
        "shortages": [
          {
            "fi": "Sisäänkäynnissä on ahdas tuulikaappi.",
            "sv": "Det finns ett trångt vindfång vid ingången.",
            "en": "The entrance has a cramped foyer."
          }
        ]
      },
      {
        "id": "32",
        "name": {
          "fi": "Olen rollaattorin käyttäjä - saavun omalla autolla",
          "sv": "Jag är en rollatoranvändare - kommer med min egen bil",
          "en": "I am a rollator user - arrive by my car"
        },
        "value": "red",
        "shortages": [
          {
            "fi": "Esteettömiä autopaikkoja ei ole.",
            "sv": "Inga p-platser för personer med rörelsehinder.",
            "en": "No parking places for persons with a disability."
          },
          {
            "fi": "Sisäänkäynnissä on ahdas tuulikaappi.",
            "sv": "Det finns ett trångt vindfång vid ingången.",
            "en": "The entrance has a cramped foyer."
          }
        ]
      },
      {
        "id": "33",
        "name": {
          "fi": "Olen rollaattorin käyttäjä - saavun saattoliikenteellä",
          "sv": "Jag är en rollatoranvändare - kommer med angöringstrafik",
          "en": "I am a rollator user - arrive with pick-up and drop-off traffic"
        },
        "value": "red",
        "shortages": [
          {
            "fi": "Sisäänkäynnissä on ahdas tuulikaappi.",
            "sv": "Det finns ett trångt vindfång vid ingången.",
            "en": "The entrance has a cramped foyer."
          }
        ]
      },
      {
        "id": "41",
        "name": {
          "fi": "Minulla on lastenvaunut",
          "sv": "Jag är en barnvagnsdragare",
          "en": "I am a stroller pusher"
        },
        "value": "green",
        "shortages": [
          {
            "fi": "Ei puutteita.",
            "sv": "Inga brister.",
            "en": "No shortcomings."
          }
        ]
      },
      {
        "id": "51",
        "name": {
          "fi": "Olen näkövammainen",
          "sv": "Jag är synskadad",
          "en": "I am visually impaired"
        },
        "value": "red",
        "shortages": [
          {
            "fi": "Sisätilojen kulkureiteillä ei ole liikkumista ohjaavaa pintamateriaalia (tummuus- tai tuntokontrasti).",
            "sv": "Rutterna inomhus saknar ytmaterial ger anvisningar om hur man tar sig fram (ljushets- eller materialkontrast).",
            "en": "The indoor routes do not have guiding surface materials (colour or tactile contrast)."
          },
          {
            "fi": "Sisätilojen lasiovissa ei ole kontrastimerkintöjä.",
            "sv": "Det finns inga kontrastmarkeringar på glasdörrarna inomhus.",
            "en": "The glass doors in the indoor area do not have contrast markings."
          }
        ]
      },
      {
        "id": "52",
        "name": {
          "fi": "Olen näkövammainen - saavun saattoliikenteellä",
          "sv": "Jag är synskadad - kommer med angöringstrafik",
          "en": "I am visually impaired - arrive with pick-up and drop-off traffic"
        },
        "value": "red",
        "shortages": [
          {
            "fi": "Sisätilojen kulkureiteillä ei ole liikkumista ohjaavaa pintamateriaalia (tummuus- tai tuntokontrasti).",
            "sv": "Rutterna inomhus saknar ytmaterial ger anvisningar om hur man tar sig fram (ljushets- eller materialkontrast).",
            "en": "The indoor routes do not have guiding surface materials (colour or tactile contrast)."
          },
          {
            "fi": "Sisätilojen lasiovissa ei ole kontrastimerkintöjä.",
            "sv": "Det finns inga kontrastmarkeringar på glasdörrarna inomhus.",
            "en": "The glass doors in the indoor area do not have contrast markings."
          }
        ]
      }
    ],
    "sentences": [
      {
        "sentenceGroupName": "Saattoliikenne",
        "sentenceGroup": {
          "fi": "Reitti pääsisäänkäynnille",
          "sv": "Rutten till huvudingången",
          "en": "The route to the main entrance"
        },
        "sentence": {
          "fi": "Saattoliikenteen pysähtymispaikka sijaitsee sisäänkäynnin läheisyydessä (etäisyys enintään 5 metriä), josta sisäänkäynnille pääsee siirtymään sujuvasti.",
          "sv": "Hållplatsen för skjutstrafik ligger i närheten av ingången, på en plats varifrån det är lätt att ta sig till trottoaren.",
          "en": "The pick-up and drop-off area is located in the vicinity of the entrance, giving easy access to the pavement."
        }
      },
      {
        "sentenceGroupName": "Kulkureitti pääsisäänkäynnille",
        "sentenceGroup": {
          "fi": "Reitti pääsisäänkäynnille",
          "sv": "Rutten till huvudingången",
          "en": "The route to the main entrance"
        },
        "sentence": {
          "fi": "Kulkureitti sisäänkäynnille on tasainen ja riittävän leveä sekä valaistu.",
          "sv": "Rutten till ingången är jämn och tillräckligt bred samt belyst.",
          "en": "The route to the entrance is smooth and sufficiently wide and illuminated."
        }
      },
      {
        "sentenceGroupName": "Kulkureitti pääsisäänkäynnille",
        "sentenceGroup": {
          "fi": "Reitti pääsisäänkäynnille",
          "sv": "Rutten till huvudingången",
          "en": "The route to the main entrance"
        },
        "sentence": {
          "fi": "Kulkureitillä on 2 peräkkäistä porrasaskelmaa, jossa on käsijohteet molemmilla puolilla.",
          "sv": "På rutten finns 2 trappsteg efter varandra med räcken på båda sidorna.",
          "en": "The passage has 2 consecutive steps with handrails on both sides."
        }
      },
      {
        "sentenceGroupName": "Kulkureitti pääsisäänkäynnille",
        "sentenceGroup": {
          "fi": "Reitti pääsisäänkäynnille",
          "sv": "Rutten till huvudingången",
          "en": "The route to the main entrance"
        },
        "sentence": {
          "fi": "Kulkureitillä on alle 6 m pitkä luiska, jossa on käsijohteet molemmilla puolilla.",
          "sv": "På rutten finns en under 6 m lång ramp med räcken på båda sidorna.",
          "en": "The route has a ramp under 6 m long, with handrails on both sides."
        }
      },
      {
        "sentenceGroupName": "Pääsisäänkäynti",
        "sentenceGroup": {
          "fi": "Pääsisäänkäynti",
          "sv": "Huvudingången",
          "en": "The main entrance"
        },
        "sentence": {
          "fi": "Sisäänkäynti erottuu selkeästi ja on valaistu. Sisäänkäynnin yläpuolella on katos.",
          "sv": "Ingången är lätt att urskilja och belyst. Ingången har ett tak.",
          "en": "The entrance stands out clearly and is illuminated. There is a canopy above the entrance."
        }
      },
      {
        "sentenceGroupName": "Pääsisäänkäynti",
        "sentenceGroup": {
          "fi": "Pääsisäänkäynti",
          "sv": "Huvudingången",
          "en": "The main entrance"
        },
        "sentence": {
          "fi": "Sisäänkäynnin yhteydessä on 2 peräkkäistä porrasaskelmaa, jossa on käsijohteet molemmilla puolilla.",
          "sv": "Vid ingången finns 2 trappsteg efter varandra med räcken på båda sidorna.",
          "en": "In connection with the entrance, there are 2 consecutive steps with handrails on both sides."
        }
      },
      {
        "sentenceGroupName": "Pääsisäänkäynti",
        "sentenceGroup": {
          "fi": "Pääsisäänkäynti",
          "sv": "Huvudingången",
          "en": "The main entrance"
        },
        "sentence": {
          "fi": "Sisäänkäynnin yhteydessä on alle 6 m pitkä luiska, jossa on käsijohteet molemmilla puolilla.",
          "sv": "Vid ingången finns en under 6 m lång ramp med räcken på båda sidorna.",
          "en": "The entrance has a ramp under 6 m long, with handrails on both sides."
        }
      },
      {
        "sentenceGroupName": "Pääsisäänkäynti",
        "sentenceGroup": {
          "fi": "Pääsisäänkäynti",
          "sv": "Huvudingången",
          "en": "The main entrance"
        },
        "sentence": {
          "fi": "Sisäänkäynnin ovet erottuvat selkeästi. Oven ulkopuolella on riittävästi vapaata tilaa liikkumiselle esim. pyörätuolin kanssa. Ovi avautuu käsin helposti.",
          "sv": "Dörrarna vid ingången är lätta att urskilja. Utanför dörren finns tillräckligt med fritt utrymme för att röra sig t.ex. med rullstol. Dörren är lätt att öppna för hand.",
          "en": "The doors connected to the entrance stand out clearly. Outside the door there is sufficient room for moving e.g. with a wheelchair. The door opens easily manually."
        }
      },
      {
        "sentenceGroupName": "Pääsisäänkäynti",
        "sentenceGroup": {
          "fi": "Pääsisäänkäynti",
          "sv": "Huvudingången",
          "en": "The main entrance"
        },
        "sentence": {
          "fi": "Tuulikaappi on ahdas.",
          "sv": "Vindfånget är trångt.",
          "en": "The foyer is cramped."
        }
      },
      {
        "sentenceGroupName": "Sisätilat",
        "sentenceGroup": {
          "fi": "Sisätilat",
          "sv": "I lokalen",
          "en": "In the facility"
        },
        "sentence": {
          "fi": "Toimipiste sijaitsee samassa kerroksessa kuin sisäänkäynti.",
          "sv": "Verksamhetsstället ligger på samma plan som ingången.",
          "en": "The customer service point is located on the same floor as the entrance."
        }
      },
      {
        "sentenceGroupName": "Sisätilat",
        "sentenceGroup": {
          "fi": "Sisätilat",
          "sv": "I lokalen",
          "en": "In the facility"
        },
        "sentence": {
          "fi": "Sisätilojen ovet erottuvat selkeästi.",
          "sv": "Dörrarna i lokalen är lätta att urskilja.",
          "en": "The doors in the facility stand out clearly."
        }
      },
      {
        "sentenceGroupName": "Sisätilat",
        "sentenceGroup": {
          "fi": "Sisätilat",
          "sv": "I lokalen",
          "en": "In the facility"
        },
        "sentence": {
          "fi": "Toimipisteessä on esteetön wc.",
          "sv": "I verksamhetslokalen finns en tillgänglig toalett.",
          "en": "The facility has an accessible toilet."
        }
      }
    ],
    "shortcomings": [
      {
        "profile": "reduced_mobility",
        "count": 1
      },
      {
        "profile": "rollator",
        "count": 2
      },
      {
        "profile": "visually_impaired",
        "count": 2
      },
      {
        "profile": "wheelchair",
        "count": 2
      }
    ]
  }
}
```


[US-103]: https://helsinkisolutionoffice.atlassian.net/browse/US-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ