### PR TITLE
US-109 | feat: import venues' target groups from service description registry

### DIFF
--- a/graphql/src/schemas/location.ts
+++ b/graphql/src/schemas/location.ts
@@ -12,6 +12,7 @@ export const locationSchema = gql`
     description: LanguageString
     serviceOwner: ServiceOwner
     resources: [Resource!]!
+    targetGroups: [TargetGroup]
     descriptionResources: DescriptionResources
     partOf: Venue
     openingHours: OpeningHours
@@ -36,6 +37,16 @@ export const locationSchema = gql`
       @origin(service: "linked", type: "event", attr: "location_extra_info")
     administrativeDivisions: [AdministrativeDivision]
     venue: Venue
+  }
+  enum TargetGroup {
+    ASSOCIATIONS
+    CHILDREN_AND_FAMILIES
+    DISABLED
+    ELDERLY_PEOPLE
+    ENTERPRISES
+    IMMIGRANTS
+    INDIVIDUALS
+    YOUTH
   }
   enum ProviderType {
     ASSOCIATION

--- a/sources/ingest/importers/tests/test_target_groups.py
+++ b/sources/ingest/importers/tests/test_target_groups.py
@@ -1,0 +1,79 @@
+import pytest
+
+from ..location import get_unit_id_to_target_groups_mapping, TargetGroup
+
+MOCKED_SERVICE_REGISTRY_DESCRIPTION_VIEWPOINT_RESPONSE = [
+    {
+        "id": 11,
+        "target_groups": ["CHILDREN_AND_FAMILIES", "INDIVIDUALS", "YOUTH"],
+        "unit_ids": [1, 2, 3, 4, 5],
+    },
+    {"id": 12, "target_groups": ["IMMIGRANTS"], "unit_ids": [1, 3, 13, 36]},
+    {"id": 634, "target_groups": [], "unit_ids": [1234]},
+    {
+        "id": 634,
+        "target_groups": [
+            "ASSOCIATIONS",
+            "CHILDREN_AND_FAMILIES",
+            "DISABLED",
+            "ELDERLY_PEOPLE",
+            "IMMIGRANTS",
+            "INDIVIDUALS",
+            "YOUTH",
+        ],
+        "unit_ids": [2, 5],
+    },
+]
+
+
+@pytest.fixture
+def mocked_service_registry_description_viewpoint_response(mocker):
+    return mocker.patch(
+        "ingest.importers.location.request_json",
+        return_value=MOCKED_SERVICE_REGISTRY_DESCRIPTION_VIEWPOINT_RESPONSE,
+    )
+
+
+def test_get_unit_id_to_target_groups_mapping(
+    mocked_service_registry_description_viewpoint_response,
+):
+    assert get_unit_id_to_target_groups_mapping() == {
+        "1": {
+            TargetGroup.CHILDREN_AND_FAMILIES,
+            TargetGroup.IMMIGRANTS,
+            TargetGroup.INDIVIDUALS,
+            TargetGroup.YOUTH,
+        },
+        "2": {
+            TargetGroup.ASSOCIATIONS,
+            TargetGroup.CHILDREN_AND_FAMILIES,
+            TargetGroup.DISABLED,
+            TargetGroup.ELDERLY_PEOPLE,
+            TargetGroup.IMMIGRANTS,
+            TargetGroup.INDIVIDUALS,
+            TargetGroup.YOUTH,
+        },
+        "3": {
+            TargetGroup.CHILDREN_AND_FAMILIES,
+            TargetGroup.IMMIGRANTS,
+            TargetGroup.INDIVIDUALS,
+            TargetGroup.YOUTH,
+        },
+        "4": {
+            TargetGroup.CHILDREN_AND_FAMILIES,
+            TargetGroup.INDIVIDUALS,
+            TargetGroup.YOUTH,
+        },
+        "5": {
+            TargetGroup.ASSOCIATIONS,
+            TargetGroup.CHILDREN_AND_FAMILIES,
+            TargetGroup.DISABLED,
+            TargetGroup.ELDERLY_PEOPLE,
+            TargetGroup.IMMIGRANTS,
+            TargetGroup.INDIVIDUALS,
+            TargetGroup.YOUTH,
+        },
+        "13": {TargetGroup.IMMIGRANTS},
+        "36": {TargetGroup.IMMIGRANTS},
+        "1234": set(),
+    }


### PR DESCRIPTION
## Description

### feat: import venues' target groups from service description registry

`python manage.py ingest_data location` will now import venues' target
groups from service description registry (palvelukuvausrekisteri in
Finnish).

A single venue can belong to zero or more of these target groups:
 - ASSOCIATIONS
 - CHILDREN_AND_FAMILIES
 - DISABLED
 - ELDERLY_PEOPLE
 - ENTERPRISES
 - IMMIGRANTS
 - INDIVIDUALS
 - YOUTH

refs US-109

## Tickets

- [US-109](https://helsinkisolutionoffice.atlassian.net/browse/US-109)

## Manual testing

- checkout this PR's branch's version
  - `cp .env.example .env`
  - `docker-compose up --build`
  - `docker exec -it unified-search_sources_1 bash`
    - `python manage.py ingest_data location --use-fallback-languages`
    - Open http://localhost:5601/app/dev_tools#/console and fetch data [1]

[1] fetch data:
```
GET _search
{
  "query": {
    "match_all": {}
  }
}
```

### Example of manual testing

Fetched data for unit 28414:
```
GET _search
{
  "query": {
    "match": {
   "venue.meta.id": "28414"
    }
  }
}
```

Part of result:
```json
...
          "venue" : {
            "meta" : {
              "id" : "28414",
              "createdAt" : "2023-08-01T15:19:55.169545",
              "updatedAt" : null
            },
            "name" : {
              "fi" : "Business Helsinki",
              "sv" : "Business Helsinki",
              "en" : "Business Helsinki"
            },
            "location" : {
              "url" : {
                "fi" : "https://www.hel.fi/fi/yritykset-ja-tyo",
                "sv" : "https://www.hel.fi/sv/foretag-och-arbete",
                "en" : "https://www.hel.fi/en/business-and-work"
              },
...
            "targetGroups" : [
              "ASSOCIATIONS",
              "ENTERPRISES",
              "IMMIGRANTS"
            ],
...
```

So for unit 28414 the target groups have been calculated to be:
 - ASSOCIATIONS
 - ENTERPRISES
 - IMMIGRANTS

As a manual check we can look at the data from service description registry (palvelukuvausrekisteri in Finnish):
 - https://www.hel.fi/palvelukarttaws/rest/vpalvelurekisteri/description/?alldata=yes
searching with 28414:

Services with 28414 listed in unit_ids:
- service ID 2997 → "target_groups": ["ENTERPRISES", "IMMIGRANTS"]
- service ID 7527 → "target_groups": ["ENTERPRISES"]
- service ID 2445 → "target_groups": []
- service ID 2692 → "target_groups": ["ASSOCIATIONS", "ENTERPRISES"]
- service ID 4227 → "target_groups": []
- service ID 4982 → "target_groups": ["ENTERPRISES"]

Looking at the distinct target groups from all these above services combined:
 - ASSOCIATIONS (From service 2692)
 - ENTERPRISES (From services 2997, 7527, 2692, 4982)
 - IMMIGRANTS (From service 2997)

So for this unit we got the same data from unified search query. ✅

[US-109]: https://helsinkisolutionoffice.atlassian.net/browse/US-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ