### PR TITLE
US-100 | feat(ingest_data): use fallback languages (Order: fi, en, sv) by default

### DIFF
--- a/sources/ingest/importers/base.py
+++ b/sources/ingest/importers/base.py
@@ -41,7 +41,7 @@ class Importer(ABC, Generic[IndexableData]):
 
     index_base_names: Tuple[str, ...]
 
-    def __init__(self, use_fallback_languages=False) -> None:
+    def __init__(self, use_fallback_languages=True) -> None:
         if not getattr(self, "index_base_names", None):
             raise NotImplementedError(
                 f"Importer {self.__class__.__name__} is missing index_base_names."

--- a/sources/ingest/management/commands/ingest_data.py
+++ b/sources/ingest/management/commands/ingest_data.py
@@ -46,9 +46,14 @@ class Command(BaseCommand):
             help="Delete stored data",
         )
         parser.add_argument(
-            "--use-fallback-languages",
-            action="store_true",
-            help="Use fallback languages (Order: fi, en, sv)",
+            "--ignore-fallback-languages",  # Turn off use_fallback_languages
+            dest="use_fallback_languages",
+            action="store_false",  # Means use_fallback_languages=False because of dest
+            default=True,  # Means use_fallback_languages=True because of dest
+            help=(
+                "Ignore the use of fallback languages. By default "
+                "fallback languages are used in order fi, en, sv."
+            ),
         )
 
         # Positional (optional) argument(s)
@@ -70,7 +75,7 @@ class Command(BaseCommand):
 
         self.handle_import(
             importer_map,
-            use_fallback_languages=kwargs.get("use_fallback_languages", False),
+            use_fallback_languages=kwargs.get("use_fallback_languages", True),
         )
 
         end_time = timezone.now()


### PR DESCRIPTION
## Description

### feat(ingest_data): use fallback languages (Order: fi, en, sv) by default

Switch from
 - not using fallback languages by default
 - providing an option to use them with --use-fallback-languages

to
 - using fallback languages by default
 - providing an option to not use them with --ignore-fallback-languages

refs US-100

## Tickets

[US-100](https://helsinkisolutionoffice.atlassian.net/browse/US-100)

[US-100]: https://helsinkisolutionoffice.atlassian.net/browse/US-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ