### PR TITLE
US-109 | fix(graphql): rename Venue to UnifiedSearchVenue & sync schema comments

### DIFF
--- a/graphql/src/schemas/location.ts
+++ b/graphql/src/schemas/location.ts
@@ -5,7 +5,7 @@ export const locationSchema = gql`
   respa unit or resource, service map unit, beta.kultus venue, linked
   events place, Kukkuu venue
   """
-  type Venue {
+  type UnifiedSearchVenue {
     meta: NodeMeta
     name: LanguageString
     location: LocationDescription @cacheControl(inheritMaxAge: true)
@@ -14,7 +14,7 @@ export const locationSchema = gql`
     resources: [Resource!]!
     targetGroups: [TargetGroup]
     descriptionResources: DescriptionResources
-    partOf: Venue
+    partOf: UnifiedSearchVenue
     openingHours: OpeningHours
     manager: LegalEntity
     contactDetails: ContactInfo
@@ -36,7 +36,7 @@ export const locationSchema = gql`
     explanation: String
       @origin(service: "linked", type: "event", attr: "location_extra_info")
     administrativeDivisions: [AdministrativeDivision]
-    venue: Venue
+    venue: UnifiedSearchVenue
   }
   enum TargetGroup {
     ASSOCIATIONS

--- a/graphql/src/schemas/query.ts
+++ b/graphql/src/schemas/query.ts
@@ -45,7 +45,7 @@ export const querySchema = gql`
   type SearchResultNode {
     _score: Float
     id: ID!
-    venue: Venue @cacheControl(inheritMaxAge: true)
+    venue: UnifiedSearchVenue @cacheControl(inheritMaxAge: true)
     event: Event
     searchCategories: [UnifiedSearchResultCategory!]!
   }

--- a/graphql/src/schemas/shared.ts
+++ b/graphql/src/schemas/shared.ts
@@ -8,7 +8,7 @@ export const sharedSchema = gql`
   }
   """
   TODO: merge all free tags, categories, and keywords
-  KEYWORDS ARE GIVEN FROM events-proxy (https://tapahtumat-proxy.test.kuva.hel.ninja/proxy/graphql)
+  KEYWORDS ARE GIVEN FROM events-proxy (https://events-graphql-proxy.test.hel.ninja/proxy/graphql)
   """
   type KeywordString {
     name: String!


### PR DESCRIPTION
## Description

### fix(graphql): rename Venue to UnifiedSearchVenue & sync schema comments

City-of-Helsinki/unified-search GraphQL schema is used as a subgraph in
City-of-Helsinki/events-helsinki-monorepo project's
events-graphql-federation supergraph. There are changes done directly
into the subgraph without having done them into unified search's
schemas, see
/proxies/events-graphql-federation/subgraphs/unified-search/README.md:

> WARNING: There is conflict with the Venue type, so it's renamed in
> supergraph, but not yet deployed in the actual server.

Sync those changes from events-helsinki-monorepo repository's
events-helsinki-graphql-federation's unified-search.graphql subgraph
back into this repository.

refs US-109 (trying to test this with events-helsinki-monorepo)

## Tickets

[US-109](https://helsinkisolutionoffice.atlassian.net/browse/US-109) (trying to test this with events-helsinki-monorepo)


[US-109]: https://helsinkisolutionoffice.atlassian.net/browse/US-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ