### PR TITLE
US-109 | fix(graphql): fix resolving of UnifiedSearchVenue type after rename

### DIFF
--- a/graphql/src/index.ts
+++ b/graphql/src/index.ts
@@ -234,7 +234,7 @@ const resolvers = {
     },
   },
 
-  Venue: {
+  UnifiedSearchVenue: {
     name({ venue }: any, args: any, context: any, info: any) {
       return venue.name;
     },


### PR DESCRIPTION
## Description

### fix(graphql): fix resolving of UnifiedSearchVenue type after rename

refs US-109 (renamed Venue to UnifiedSearchVenue in PR #104)

## Tickets

[US-109](https://helsinkisolutionoffice.atlassian.net/browse/US-109)

[US-109]: https://helsinkisolutionoffice.atlassian.net/browse/US-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ