### PR TITLE
US-111 | fix: change fallback language order from fi/en/sv to en/fi/sv

### DIFF
--- a/sources/ingest/importers/utils/language.py
+++ b/sources/ingest/importers/utils/language.py
@@ -52,8 +52,8 @@ class LanguageStringConverter:
         return {
             lang: (
                 fields.get(lang, None)
-                or fields.get("fi", None)  # Primary fallback language
-                or fields.get("en", None)  # Secondary fallback language
+                or fields.get("en", None)  # Primary fallback language
+                or fields.get("fi", None)  # Secondary fallback language
                 or fields.get("sv", None)  # Tertiary fallback language
             )
             for lang in fields.keys()

--- a/sources/ingest/management/commands/ingest_data.py
+++ b/sources/ingest/management/commands/ingest_data.py
@@ -52,7 +52,7 @@ class Command(BaseCommand):
             default=True,  # Means use_fallback_languages=True because of dest
             help=(
                 "Ignore the use of fallback languages. By default "
-                "fallback languages are used in order fi, en, sv."
+                "fallback languages are used in order en, fi, sv."
             ),
         )
 

--- a/sources/ingest/tests/test_language.py
+++ b/sources/ingest/tests/test_language.py
@@ -68,7 +68,7 @@ def test_get_language_string_without_fallback_languages(
         (
             {"foo_fi": "kissa", "foo_en": "cat", "bar_fi": "koira"},
             "foo",
-            LanguageString(fi="kissa", sv="kissa", en="cat"),
+            LanguageString(fi="kissa", sv="cat", en="cat"),
         ),
         (
             {"foo_fi": "kissa", "bar_fi": "koira"},
@@ -120,7 +120,7 @@ def test_get_language_string_without_fallback_languages(
         (
             {"foo_fi": "kissa", "foo_en": "cat"},
             "foo",
-            LanguageString(fi="kissa", sv="kissa", en="cat"),
+            LanguageString(fi="kissa", sv="cat", en="cat"),
         ),
         (
             {"foo_fi": "kissa", "foo_sv": "katt"},
@@ -155,12 +155,12 @@ def test_get_language_string_without_fallback_languages(
         (
             {"foo_fi": "kissa", "foo_en": "cat", "foo_sv": ""},
             "foo",
-            LanguageString(fi="kissa", sv="kissa", en="cat"),
+            LanguageString(fi="kissa", sv="cat", en="cat"),
         ),
         (
             {"foo_fi": "kissa", "foo_en": "cat", "foo_sv": None},
             "foo",
-            LanguageString(fi="kissa", sv="kissa", en="cat"),
+            LanguageString(fi="kissa", sv="cat", en="cat"),
         ),
     ],
 )


### PR DESCRIPTION
## Description

### fix: change fallback language order from fi/en/sv to en/fi/sv

refs US-111 (changing fallback language order to en/fi/sv)
refs HH-110 (the original fallback languages order defined)
refs LIIKUNTA-547 (City-of-Helsinki/events-helsinki-monorepo#420 used fallback language order en/fi/sv)

## Tickets

- [US-111](https://helsinkisolutionoffice.atlassian.net/browse/US-111)
- [HH-110](https://helsinkisolutionoffice.atlassian.net/browse/HH-110)
- [LIIKUNTA-547](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-547)

[US-111]: https://helsinkisolutionoffice.atlassian.net/browse/US-111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HH-110]: https://helsinkisolutionoffice.atlassian.net/browse/HH-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIIKUNTA-547]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ