### PR TITLE
US-112 | fix: fix unknown and zero accessibility shortcoming counts

### DIFF
--- a/graphql/src/schemas/location.ts
+++ b/graphql/src/schemas/location.ts
@@ -89,10 +89,10 @@ export const locationSchema = gql`
     green
   }
   type AccessibilityViewpoint {
-    id: ID
-    name: LanguageString
-    value: AccessibilityViewpointValue
-    shortages: [LanguageString]
+    id: ID!
+    name: LanguageString!
+    value: AccessibilityViewpointValue!
+    shortages: [LanguageString!]!
   }
   enum AccessibilityProfile {
     hearing_aid
@@ -103,7 +103,7 @@ export const locationSchema = gql`
     wheelchair
   }
   type AccessibilityShortcoming {
-    profile: AccessibilityProfile
+    profile: AccessibilityProfile!
     count: Int
   }
   type AccessibilitySentence {
@@ -115,9 +115,9 @@ export const locationSchema = gql`
     email: String
     phone: String
     www: String
-    viewpoints: [AccessibilityViewpoint]
-    sentences: [AccessibilitySentence]
-    shortcomings: [AccessibilityShortcoming]
+    viewpoints: [AccessibilityViewpoint!]!
+    sentences: [AccessibilitySentence!]!
+    shortcomings: [AccessibilityShortcoming!]!
   }
   enum ResourceMainType {
     item

--- a/sources/ingest/importers/tests/test_fix_unknown_and_zero_shortcomings.py
+++ b/sources/ingest/importers/tests/test_fix_unknown_and_zero_shortcomings.py
@@ -1,0 +1,349 @@
+from typing import List
+
+import pytest
+
+from ..location import (
+    Accessibility,
+    AccessibilityShortcoming,
+    AccessibilityViewpoint,
+    AccessibilityViewpointID as VpID,
+    AccessibilityViewpointValue,
+    NO_SHORTCOMINGS_SHORTAGE_TEXT_VARIANTS,
+)
+from ..utils.shared import LanguageString
+
+SHORTAGE_1, SHORTAGE_2, SHORTAGE_3 = [
+    LanguageString(fi=f"Puute {i}", sv=f"Brist {i}", en=f"Shortage {i}")
+    for i in [1, 2, 3]
+]
+SHORTAGES_1_2 = [SHORTAGE_1, SHORTAGE_2]
+SHORTAGES_1_2_3 = [SHORTAGE_1, SHORTAGE_2, SHORTAGE_3]
+
+
+ALL_GREEN_SHORTCOMINGS = [
+    AccessibilityShortcoming(profile="hearing_aid", count=0),
+    AccessibilityShortcoming(profile="reduced_mobility", count=0),
+    AccessibilityShortcoming(profile="rollator", count=0),
+    AccessibilityShortcoming(profile="stroller", count=0),
+    AccessibilityShortcoming(profile="visually_impaired", count=0),
+    AccessibilityShortcoming(profile="wheelchair", count=0),
+]
+
+ALL_UNKNOWN_SHORTCOMINGS = [
+    AccessibilityShortcoming(profile="hearing_aid", count=None),
+    AccessibilityShortcoming(profile="reduced_mobility", count=None),
+    AccessibilityShortcoming(profile="rollator", count=None),
+    AccessibilityShortcoming(profile="stroller", count=None),
+    AccessibilityShortcoming(profile="visually_impaired", count=None),
+    AccessibilityShortcoming(profile="wheelchair", count=None),
+]
+
+TEST_VIEWPOINT_NAME = LanguageString(fi="Testi", sv="Test", en="Test")
+
+
+def _green(viewpoint_id: VpID) -> AccessibilityViewpoint:
+    """
+    Create an AccessibilityViewpoint with "green" value
+    """
+    return AccessibilityViewpoint(
+        id=viewpoint_id.value,
+        value=AccessibilityViewpointValue.GREEN.value,
+        name=TEST_VIEWPOINT_NAME,
+        shortages=NO_SHORTCOMINGS_SHORTAGE_TEXT_VARIANTS,
+    )
+
+
+def _unknown(viewpoint_id: VpID) -> AccessibilityViewpoint:
+    """
+    Create an AccessibilityViewpoint with "unknown" value
+    """
+    return AccessibilityViewpoint(
+        id=viewpoint_id.value,
+        value=AccessibilityViewpointValue.UNKNOWN.value,
+        name=TEST_VIEWPOINT_NAME,
+        shortages=[],
+    )
+
+
+def _red(viewpoint_id: VpID, *shortages: LanguageString) -> AccessibilityViewpoint:
+    """
+    Create an AccessibilityViewpoint with "red" value and given shortages
+    """
+    return AccessibilityViewpoint(
+        id=viewpoint_id.value,
+        value=AccessibilityViewpointValue.RED.value,
+        name=TEST_VIEWPOINT_NAME,
+        shortages=[*shortages],
+    )
+
+
+ALL_GREEN_VIEWPOINTS = [_green(viewpoint_id) for viewpoint_id in VpID]
+ALL_UNKNOWN_VIEWPOINTS = [_unknown(viewpoint_id) for viewpoint_id in VpID]
+ALL_RED_VIEWPOINTS_WITH_SHORTAGES = [
+    _red(viewpoint_id, *SHORTAGES_1_2_3) for viewpoint_id in VpID
+]
+ALL_RED_VIEWPOINTS_WITHOUT_SHORTAGES = [_red(viewpoint_id) for viewpoint_id in VpID]
+
+
+def make_test_accessibility(
+    viewpoints: List[AccessibilityViewpoint],
+    shortcomings: List[AccessibilityShortcoming],
+) -> Accessibility:
+    """
+    Create a test Accessibility object with given viewpoints and shortcomings
+    """
+    return Accessibility(
+        email="test_email",
+        phone="test_phone",
+        www="test_www",
+        viewpoints=viewpoints,
+        sentences=[],
+        shortcomings=shortcomings,
+    )
+
+
+def test_shortages_not_set_raises_error():
+    accessibility = make_test_accessibility(
+        viewpoints=[
+            AccessibilityViewpoint(
+                id=VpID.WHEELCHAIR.value,
+                value=AccessibilityViewpointValue.RED.value,
+                name=TEST_VIEWPOINT_NAME,
+                shortages=None,
+            )
+        ],
+        shortcomings=[],
+    )
+    with pytest.raises(ValueError):
+        accessibility.fix_unknown_and_zero_shortcomings()
+
+
+@pytest.mark.parametrize(
+    "viewpoint_value",
+    [
+        AccessibilityViewpointValue.RED,
+        AccessibilityViewpointValue.GREEN,
+        AccessibilityViewpointValue.UNKNOWN,
+    ],
+)
+@pytest.mark.parametrize(
+    "shortages",
+    [[], NO_SHORTCOMINGS_SHORTAGE_TEXT_VARIANTS, [SHORTAGE_1], SHORTAGES_1_2_3],
+)
+def test_choose_accessibility_perspective_viewpoint_is_ignored(
+    viewpoint_value: AccessibilityViewpointValue,
+    shortages: List[LanguageString],
+):
+    accessibility = make_test_accessibility(
+        viewpoints=[
+            AccessibilityViewpoint(
+                id=VpID.CHOOSE_ACCESSIBILITY_PERSPECTIVE.value,
+                value=viewpoint_value.value,
+                name=TEST_VIEWPOINT_NAME,
+                shortages=shortages,
+            )
+        ],
+        shortcomings=[],
+    )
+    assert accessibility.fix_unknown_and_zero_shortcomings()
+    assert accessibility.shortcomings == ALL_UNKNOWN_SHORTCOMINGS
+
+
+def test_no_data():
+    accessibility = make_test_accessibility(viewpoints=[], shortcomings=[])
+    assert accessibility.fix_unknown_and_zero_shortcomings()
+    assert accessibility.shortcomings == ALL_UNKNOWN_SHORTCOMINGS
+
+
+def test_all_unknown():
+    accessibility = make_test_accessibility(
+        viewpoints=ALL_UNKNOWN_VIEWPOINTS, shortcomings=[]
+    )
+    assert accessibility.fix_unknown_and_zero_shortcomings()
+    assert accessibility.shortcomings == ALL_UNKNOWN_SHORTCOMINGS
+
+
+def test_all_green():
+    accessibility = make_test_accessibility(
+        viewpoints=ALL_GREEN_VIEWPOINTS, shortcomings=[]
+    )
+    assert accessibility.fix_unknown_and_zero_shortcomings()
+    assert accessibility.shortcomings == ALL_GREEN_SHORTCOMINGS
+
+
+def test_partial_green_only():
+    accessibility = make_test_accessibility(
+        viewpoints=[
+            _green(VpID.REDUCED_MOBILITY_ARRIVE_BY_OWN_CAR),
+            _green(VpID.ROLLATOR_ARRIVE_BY_OWN_CAR),
+            _green(VpID.ROLLATOR_ARRIVE_BY_DROPOFF),
+            _green(VpID.VISUALLY_IMPAIRED),
+            _green(VpID.WHEELCHAIR),
+            _green(VpID.WHEELCHAIR_ARRIVE_BY_OWN_CAR),
+        ],
+        shortcomings=[],
+    )
+    assert accessibility.fix_unknown_and_zero_shortcomings()
+    assert accessibility.shortcomings == ALL_UNKNOWN_SHORTCOMINGS
+
+
+@pytest.mark.parametrize(
+    "viewpoints",
+    [
+        ALL_GREEN_VIEWPOINTS,
+        ALL_UNKNOWN_VIEWPOINTS,
+        ALL_RED_VIEWPOINTS_WITH_SHORTAGES,
+        ALL_RED_VIEWPOINTS_WITHOUT_SHORTAGES,
+    ],
+)
+def test_nothing_happens_when_all_already_red(viewpoints: List[AccessibilityViewpoint]):
+    orig_shortcomings = [
+        AccessibilityShortcoming(profile="hearing_aid", count=1),
+        AccessibilityShortcoming(profile="reduced_mobility", count=2),
+        AccessibilityShortcoming(profile="rollator", count=3),
+        AccessibilityShortcoming(profile="stroller", count=4),
+        AccessibilityShortcoming(profile="visually_impaired", count=5),
+        AccessibilityShortcoming(profile="wheelchair", count=6),
+    ]
+    accessibility = make_test_accessibility(
+        viewpoints=viewpoints, shortcomings=orig_shortcomings[:]
+    )
+    assert not accessibility.fix_unknown_and_zero_shortcomings()
+    assert len(accessibility.shortcomings) == len(orig_shortcomings)
+    assert all(
+        sc1 == sc2 for sc1, sc2 in zip(accessibility.shortcomings, orig_shortcomings)
+    )
+
+
+def test_unknown_to_red_unique_shortages_count():
+    accessibility = make_test_accessibility(
+        viewpoints=[
+            _red(VpID.HEARING_AID, *SHORTAGES_1_2),
+            _red(VpID.ROLLATOR, SHORTAGE_1),
+            _red(VpID.ROLLATOR_ARRIVE_BY_OWN_CAR, SHORTAGE_2),
+            _red(VpID.ROLLATOR_ARRIVE_BY_DROPOFF, SHORTAGE_3),
+            _red(VpID.VISUALLY_IMPAIRED, SHORTAGE_1),
+            _red(VpID.VISUALLY_IMPAIRED_ARRIVE_BY_DROPOFF, SHORTAGE_2),
+            _red(VpID.WHEELCHAIR, *SHORTAGES_1_2_3),
+            _red(VpID.WHEELCHAIR_ARRIVE_BY_OWN_CAR, SHORTAGE_2),
+            _red(VpID.WHEELCHAIR_ARRIVE_BY_DROPOFF, SHORTAGE_3),
+        ],
+        shortcomings=[],
+    )
+    assert accessibility.fix_unknown_and_zero_shortcomings()
+    assert accessibility.shortcomings == [
+        AccessibilityShortcoming(profile="hearing_aid", count=2),
+        AccessibilityShortcoming(profile="reduced_mobility", count=None),
+        AccessibilityShortcoming(profile="rollator", count=3),
+        AccessibilityShortcoming(profile="stroller", count=None),
+        AccessibilityShortcoming(profile="visually_impaired", count=2),
+        AccessibilityShortcoming(profile="wheelchair", count=3),
+    ]
+
+
+def test_all_red_but_no_shortages_means_unknown():
+    accessibility = make_test_accessibility(
+        viewpoints=ALL_RED_VIEWPOINTS_WITHOUT_SHORTAGES,
+        shortcomings=[],
+    )
+    assert accessibility.fix_unknown_and_zero_shortcomings()
+    assert accessibility.shortcomings == ALL_UNKNOWN_SHORTCOMINGS
+
+
+def test_all_or_partial_red_but_no_real_shortages_means_unknown():
+    accessibility = make_test_accessibility(
+        viewpoints=[
+            # Hearing aid -> unknown
+            # - profile with a single viewpoint
+            # - red but no real shortages i.e. only texts meaning "no shortages"
+            _red(VpID.HEARING_AID, *NO_SHORTCOMINGS_SHORTAGE_TEXT_VARIANTS),
+            # Reduced mobility -> unknown
+            # - profile with 3 viewpoints
+            # - no unknowns
+            # - reds but no shortages
+            _red(VpID.REDUCED_MOBILITY),
+            _red(VpID.REDUCED_MOBILITY_ARRIVE_BY_OWN_CAR),
+            _green(VpID.REDUCED_MOBILITY_ARRIVE_BY_DROPOFF),
+            # Rollator -> unknown
+            # - profile with 3 viewpoints
+            # - no unknowns
+            # - reds but shortages
+            _green(VpID.ROLLATOR),
+            _red(VpID.ROLLATOR_ARRIVE_BY_OWN_CAR),
+            _red(VpID.ROLLATOR_ARRIVE_BY_DROPOFF),
+            # Stroller -> unknown
+            # - profile with a single viewpoint
+            # - red but no shortages
+            _red(VpID.STROLLER),
+            # Visually impaired -> unknown
+            # - profile with 2 viewpoints
+            # - no unknowns
+            # - red but no shortages
+            _green(VpID.VISUALLY_IMPAIRED),
+            _red(VpID.VISUALLY_IMPAIRED_ARRIVE_BY_DROPOFF),
+            # Wheelchair -> unknown
+            # - profile with 3 viewpoints
+            # - no unknowns
+            # - reds but no shortages
+            _green(VpID.WHEELCHAIR),
+            _red(VpID.WHEELCHAIR_ARRIVE_BY_OWN_CAR),
+            _red(VpID.WHEELCHAIR_ARRIVE_BY_DROPOFF),
+        ],
+        shortcomings=[
+            AccessibilityShortcoming(profile="reduced_mobility", count=None),
+            AccessibilityShortcoming(profile="rollator", count=0),
+        ],
+    )
+    assert accessibility.fix_unknown_and_zero_shortcomings()
+    assert accessibility.shortcomings == ALL_UNKNOWN_SHORTCOMINGS
+
+
+def test_unknown_to_green_single_viewpoint_in_profile():
+    accessibility = make_test_accessibility(
+        viewpoints=[_green(VpID.STROLLER)], shortcomings=[]
+    )
+    assert accessibility.fix_unknown_and_zero_shortcomings()
+    assert accessibility.shortcomings == [
+        AccessibilityShortcoming(profile="hearing_aid", count=None),
+        AccessibilityShortcoming(profile="reduced_mobility", count=None),
+        AccessibilityShortcoming(profile="rollator", count=None),
+        AccessibilityShortcoming(profile="stroller", count=0),
+        AccessibilityShortcoming(profile="visually_impaired", count=None),
+        AccessibilityShortcoming(profile="wheelchair", count=None),
+    ]
+
+
+def test_unknown_to_green_multiple_viewpoints_in_profile():
+    accessibility = make_test_accessibility(
+        viewpoints=[
+            _green(VpID.WHEELCHAIR),
+            _green(VpID.WHEELCHAIR_ARRIVE_BY_OWN_CAR),
+            _green(VpID.WHEELCHAIR_ARRIVE_BY_DROPOFF),
+        ],
+        shortcomings=[],
+    )
+    assert accessibility.fix_unknown_and_zero_shortcomings()
+    assert accessibility.shortcomings == [
+        AccessibilityShortcoming(profile="hearing_aid", count=None),
+        AccessibilityShortcoming(profile="reduced_mobility", count=None),
+        AccessibilityShortcoming(profile="rollator", count=None),
+        AccessibilityShortcoming(profile="stroller", count=None),
+        AccessibilityShortcoming(profile="visually_impaired", count=None),
+        AccessibilityShortcoming(profile="wheelchair", count=0),
+    ]
+
+
+def test_unknown_to_unknown_partial_coverage_of_multiple_viewpoints_in_profile():
+    accessibility = make_test_accessibility(
+        viewpoints=[
+            _green(VpID.REDUCED_MOBILITY),
+            _green(VpID.REDUCED_MOBILITY_ARRIVE_BY_DROPOFF),
+            _green(VpID.VISUALLY_IMPAIRED),
+            _green(VpID.WHEELCHAIR),
+            _unknown(VpID.WHEELCHAIR_ARRIVE_BY_OWN_CAR),
+            _green(VpID.WHEELCHAIR_ARRIVE_BY_DROPOFF),
+        ],
+        shortcomings=[],
+    )
+    assert accessibility.fix_unknown_and_zero_shortcomings()
+    assert accessibility.shortcomings == ALL_UNKNOWN_SHORTCOMINGS

--- a/sources/ingest/importers/utils/shared.py
+++ b/sources/ingest/importers/utils/shared.py
@@ -1,12 +1,15 @@
 from dataclasses import dataclass
-from typing import Union
+from typing import Optional, Union
 
 
-@dataclass
+@dataclass(eq=True)
 class LanguageString:
-    fi: str = None
-    sv: str = None
-    en: str = None
+    fi: Optional[str] = None
+    sv: Optional[str] = None
+    en: Optional[str] = None
+
+    def __hash__(self):
+        return hash((self.fi, self.sv, self.en))
 
 
 @dataclass

--- a/sources/ingest/tests/test_language.py
+++ b/sources/ingest/tests/test_language.py
@@ -172,3 +172,53 @@ def test_get_language_string_with_fallback_languages(
 
     assert converter1.get_language_string(field_name) == expected_output
     assert converter2.get_language_string(field_name) == expected_output
+
+
+@pytest.mark.parametrize(
+    "language_strings,expected_unique_count",
+    [
+        (
+            [
+                LanguageString(fi="fi", sv="sv", en="en"),
+                LanguageString(fi="fi", sv="sv", en="en"),
+                LanguageString(fi="fi", sv="sv", en="en"),
+            ],
+            1,
+        ),
+        (
+            [
+                LanguageString(fi="fi", sv="sv", en="en"),
+                LanguageString(fi=None, sv=None, en=None),
+                LanguageString(fi=None, sv="sv", en=None),
+                LanguageString(fi=None, sv=None, en=None),
+                LanguageString(fi="fi", sv="sv", en="en"),
+            ],
+            3,
+        ),
+        (
+            [
+                LanguageString(fi="fi", sv="sv", en="en"),
+                LanguageString(fi="fi", sv="sv", en=None),
+                LanguageString(fi="fi", sv=None, en="en"),
+                LanguageString(fi=None, sv="sv", en="en"),
+                LanguageString(fi=None, sv=None, en="en"),
+                LanguageString(fi=None, sv="sv", en=None),
+                LanguageString(fi="fi", sv=None, en=None),
+                LanguageString(fi=None, sv=None, en=None),
+                LanguageString(fi="fi2", sv="sv", en="en"),
+                LanguageString(fi="fi", sv="sv2", en="en"),
+                LanguageString(fi="fi", sv="sv", en="en2"),
+                # Duplicates
+                LanguageString(fi="fi", sv="sv", en="en"),
+                LanguageString(fi="fi", sv="sv", en="en2"),
+                LanguageString(fi="fi", sv="sv", en=None),
+                LanguageString(fi="fi", sv=None, en=None),
+                LanguageString(fi=None, sv="sv", en=None),
+                LanguageString(fi=None, sv="sv", en=None),
+            ],
+            11,
+        ),
+    ],
+)
+def test_language_string_uniqueness(language_strings, expected_unique_count):
+    assert len(set(language_strings)) == expected_unique_count


### PR DESCRIPTION
## Description

### fix: fix unknown and zero accessibility shortcoming counts

refs US-112

## Tickets

[US-112](https://helsinkisolutionoffice.atlassian.net/browse/US-112)

## Manual testing with venue ID 5

Set up data locally:
- `docker compose up --build`
- `docker exec -it unified-search-sources-1 bash`
  - `python manage.py ingest_data location`

Opened http://localhost:4000/search in Insomnia and queried with:

<summary>GraphQL query</summary>

<details>

```graphql
query unifiedSearch {
  unifiedSearch(
    index: "location"
    q: "Kaunokki"
    languages: [FINNISH]) {
    edges {
      cursor
      node {
        venue {
          meta {
            id
          }
          name {
            fi
          }
          accessibility {
            viewpoints {
              id
              value
              name {
                fi
              }
              shortages {
                fi
              }
            }
            shortcomings {
              profile
              count
            }
          }
        }
      }
    }
  }
}
```
</details>

<summary>Results</summary>

<details>

```json
{
  "data": {
    "unifiedSearch": {
      "edges": [{
          "cursor": "eyJvZmZzZXQiOjF9",
          "node": {
            "venue": {
              "meta": {
                "id": "5"
              },
              "name": {
                "fi": "Päiväkoti Kaunokki"
              },
              "accessibility": {
                "viewpoints": [{
                    "id": "11",
                    "value": "red",
                    "name": {
                      "fi": "Olen pyörätuolin käyttäjä"
                    },
                    "shortages": [{
                        "fi": "Kulkureitti sisäänkäynnille ei ole tasainen."
                      }, {
                        "fi": "Kulkureitillä sisäänkäynnille on jyrkkä mäki."
                      }, {
                        "fi": "Sisäänkäynnissä on yli 2 cm korkea kynnys."
                      }, {
                        "fi": "Sisäänkäynnissä on ahdas tuulikaappi."
                      }
                    ]
                  }, {
                    "id": "12",
                    "value": "red",
                    "name": {
                      "fi": "Olen pyörätuolin käyttäjä - saavun omalla autolla"
                    },
                    "shortages": [{
                        "fi": "Esteettömiä autopaikkoja ei ole."
                      }, {
                        "fi": "Kulkureitti sisäänkäynnille ei ole tasainen."
                      }, {
                        "fi": "Kulkureitillä sisäänkäynnille on jyrkkä mäki."
                      }, {
                        "fi": "Sisäänkäynnissä on yli 2 cm korkea kynnys."
                      }, {
                        "fi": "Sisäänkäynnissä on ahdas tuulikaappi."
                      }
                    ]
                  }, {
                    "id": "13",
                    "value": "red",
                    "name": {
                      "fi": "Olen pyörätuolin käyttäjä - saavun saattoliikenteellä"
                    },
                    "shortages": [{
                        "fi": "Kulkureitti sisäänkäynnille ei ole tasainen."
                      }, {
                        "fi": "Kulkureitillä sisäänkäynnille on jyrkkä mäki."
                      }, {
                        "fi": "Sisäänkäynnissä on yli 2 cm korkea kynnys."
                      }, {
                        "fi": "Sisäänkäynnissä on ahdas tuulikaappi."
                      }
                    ]
                  }, {
                    "id": "21",
                    "value": "red",
                    "name": {
                      "fi": "Olen liikkumisesteinen, mutta kävelen"
                    },
                    "shortages": [{
                        "fi": "Kulkureitti sisäänkäynnille ei ole tasainen."
                      }, {
                        "fi": "Kulkureitillä sisäänkäynnille on jyrkkä mäki."
                      }
                    ]
                  }, {
                    "id": "22",
                    "value": "red",
                    "name": {
                      "fi": "Olen liikkumisesteinen, mutta kävelen - saavun omalla autolla"
                    },
                    "shortages": [{
                        "fi": "Esteettömiä autopaikkoja ei ole."
                      }, {
                        "fi": "Kulkureitti sisäänkäynnille ei ole tasainen."
                      }, {
                        "fi": "Kulkureitillä sisäänkäynnille on jyrkkä mäki."
                      }
                    ]
                  }, {
                    "id": "23",
                    "value": "red",
                    "name": {
                      "fi": "Olen liikkumisesteinen, mutta kävelen - saavun saattoliikenteellä"
                    },
                    "shortages": [{
                        "fi": "Kulkureitti sisäänkäynnille ei ole tasainen."
                      }, {
                        "fi": "Kulkureitillä sisäänkäynnille on jyrkkä mäki."
                      }
                    ]
                  }, {
                    "id": "31",
                    "value": "red",
                    "name": {
                      "fi": "Olen rollaattorin käyttäjä"
                    },
                    "shortages": [{
                        "fi": "Kulkureitti sisäänkäynnille ei ole tasainen."
                      }, {
                        "fi": "Kulkureitillä sisäänkäynnille on jyrkkä mäki."
                      }, {
                        "fi": "Sisäänkäynnissä on yli 2 cm korkea kynnys."
                      }, {
                        "fi": "Sisäänkäynnissä on ahdas tuulikaappi."
                      }
                    ]
                  }, {
                    "id": "32",
                    "value": "red",
                    "name": {
                      "fi": "Olen rollaattorin käyttäjä - saavun omalla autolla"
                    },
                    "shortages": [{
                        "fi": "Sisäänkäynnissä on yli 2 cm korkea kynnys."
                      }, {
                        "fi": "Sisäänkäynnissä on ahdas tuulikaappi."
                      }, {
                        "fi": "Esteettömiä autopaikkoja ei ole."
                      }, {
                        "fi": "Kulkureitti sisäänkäynnille ei ole tasainen."
                      }, {
                        "fi": "Kulkureitillä sisäänkäynnille on jyrkkä mäki."
                      }
                    ]
                  }, {
                    "id": "33",
                    "value": "red",
                    "name": {
                      "fi": "Olen rollaattorin käyttäjä - saavun saattoliikenteellä"
                    },
                    "shortages": [{
                        "fi": "Kulkureitti sisäänkäynnille ei ole tasainen."
                      }, {
                        "fi": "Kulkureitillä sisäänkäynnille on jyrkkä mäki."
                      }, {
                        "fi": "Sisäänkäynnissä on yli 2 cm korkea kynnys."
                      }, {
                        "fi": "Sisäänkäynnissä on ahdas tuulikaappi."
                      }
                    ]
                  }, {
                    "id": "41",
                    "value": "green",
                    "name": {
                      "fi": "Minulla on lastenvaunut"
                    },
                    "shortages": [{
                        "fi": "Ei puutteita."
                      }
                    ]
                  }, {
                    "id": "51",
                    "value": "red",
                    "name": {
                      "fi": "Olen näkövammainen"
                    },
                    "shortages": [{
                        "fi": "Sisätilojen kulkureiteillä ei ole liikkumista ohjaavaa pintamateriaalia (tummuus- tai tuntokontrasti)."
                      }, {
                        "fi": "Sisätilojen lasiovissa ei ole kontrastimerkintöjä."
                      }
                    ]
                  }, {
                    "id": "52",
                    "value": "red",
                    "name": {
                      "fi": "Olen näkövammainen - saavun saattoliikenteellä"
                    },
                    "shortages": [{
                        "fi": "Sisätilojen lasiovissa ei ole kontrastimerkintöjä."
                      }, {
                        "fi": "Sisätilojen kulkureiteillä ei ole liikkumista ohjaavaa pintamateriaalia (tummuus- tai tuntokontrasti)."
                      }
                    ]
                  }
                ],
                "shortcomings": [{
                    "profile": "hearing_aid",
                    "count": null
                  }, {
                    "profile": "reduced_mobility",
                    "count": 3
                  }, {
                    "profile": "rollator",
                    "count": 5
                  }, {
                    "profile": "stroller",
                    "count": 0
                  }, {
                    "profile": "visually_impaired",
                    "count": 2
                  }, {
                    "profile": "wheelchair",
                    "count": 5
                  }
                ]
              }
            }
          }
        }
      ]
    }
  }
}
```
</details>

#### TPREK Accessibility viewpoints
https://www.hel.fi/palvelukarttaws/rest/v4/accessibility_viewpoint/

<summary>Results</summary>
<details>

```json
[{
        "id": "00",
        "name_fi": "Valitse esteettömyysnäkökulma",
        "name_sv": "Välj tillgänglighetsperspektiv",
        "name_en": "Choose accessibility perspective",
        "values": ["unknown"]
    }, {
        "id": "11",
        "name_fi": "Olen pyörätuolin käyttäjä",
        "name_sv": "Jag är en rullstolsanvändare",
        "name_en": "I am a wheelchair user",
        "values": ["unknown", "green", "red"]
    }, {
        "id": "12",
        "name_fi": "Olen pyörätuolin käyttäjä - saavun omalla autolla",
        "name_sv": "Jag är en rullstolsanvändare - kommer med min egen bil",
        "name_en": "I am a wheelchair user - arrive by my car",
        "values": ["unknown", "green", "red"]
    }, {
        "id": "13",
        "name_fi": "Olen pyörätuolin käyttäjä - saavun saattoliikenteellä",
        "name_sv": "Jag är en rullstolsanvändare - kommer med angöringstrafik",
        "name_en": "I am a wheelchair user - arrive with pick-up and drop-off traffic",
        "values": ["unknown", "green", "red"]
    }, {
        "id": "21",
        "name_fi": "Olen liikkumisesteinen, mutta kävelen",
        "name_sv": "Jag är rörelsehindrad, men jag går",
        "name_en": "I have reduced mobility, but I walk",
        "values": ["unknown", "green", "red"]
    }, {
        "id": "22",
        "name_fi": "Olen liikkumisesteinen, mutta kävelen - saavun omalla autolla",
        "name_sv": "Jag är rörelsehindrad, men jag går - kommer med min egen bil",
        "name_en": "I have reduced mobility, but I walk - arrive by my car",
        "values": ["unknown", "green", "red"]
    }, {
        "id": "23",
        "name_fi": "Olen liikkumisesteinen, mutta kävelen - saavun saattoliikenteellä",
        "name_sv": "Jag är rörelsehindrad, men jag går - kommer med angöringstrafik",
        "name_en": "I have reduced mobility, but I walk - arrive with pick-up and drop-off traffic",
        "values": ["unknown", "green", "red"]
    }, {
        "id": "31",
        "name_fi": "Olen rollaattorin käyttäjä",
        "name_sv": "Jag är en rollatoranvändare",
        "name_en": "I am a rollator user",
        "values": ["unknown", "green", "red"]
    }, {
        "id": "32",
        "name_fi": "Olen rollaattorin käyttäjä - saavun omalla autolla",
        "name_sv": "Jag är en rollatoranvändare - kommer med min egen bil",
        "name_en": "I am a rollator user - arrive by my car",
        "values": ["unknown", "green", "red"]
    }, {
        "id": "33",
        "name_fi": "Olen rollaattorin käyttäjä - saavun saattoliikenteellä",
        "name_sv": "Jag är en rollatoranvändare - kommer med angöringstrafik",
        "name_en": "I am a rollator user - arrive with pick-up and drop-off traffic",
        "values": ["unknown", "green", "red"]
    }, {
        "id": "41",
        "name_fi": "Minulla on lastenvaunut",
        "name_sv": "Jag är en barnvagnsdragare",
        "name_en": "I am a stroller pusher",
        "values": ["unknown", "green", "red"]
    }, {
        "id": "51",
        "name_fi": "Olen näkövammainen",
        "name_sv": "Jag är synskadad",
        "name_en": "I am visually impaired",
        "values": ["unknown", "green", "red"]
    }, {
        "id": "52",
        "name_fi": "Olen näkövammainen - saavun saattoliikenteellä",
        "name_sv": "Jag är synskadad - kommer med angöringstrafik",
        "name_en": "I am visually impaired - arrive with pick-up and drop-off traffic",
        "values": ["unknown", "green", "red"]
    }, {
        "id": "61",
        "name_fi": "Käytän kuulolaitetta",
        "name_sv": "Jag använder en hörapparat",
        "name_en": "I use a hearing aid",
        "values": ["unknown", "green", "red"]
    }
]
```
</details>

#### TPREK Unit
https://www.hel.fi/palvelukarttaws/rest/v4/unit/5/?format=json&newfeatures=yes

<summary>Results</summary>
<details>

```json
{
    "id": 5,
    "name_fi": "Päiväkoti Kaunokki",
    "name_sv": "Päiväkoti Kaunokki",
    "name_en": "Daycare Kaunokki",
    "accessibility_viewpoints": "00:unknown,11:red,12:red,13:red,21:red,22:red,23:red,31:red,32:red,33:red,41:green,51:red,52:red,61:unknown"
}
```
</details>

#### TPREK Accessibility shortages
https://www.hel.fi/palvelukarttaws/rest/v4/unit/5/accessibility_shortage/

<summary>Results</summary>
<details>

```json
[{
        "viewpoint_id": "11",
        "shortage_fi": "Kulkureitti sisäänkäynnille ei ole tasainen.",
        "shortage_sv": "Rutten till ingången är inte jämn.",
        "shortage_en": "The route to the entrance is not even."
    }, {
        "viewpoint_id": "11",
        "shortage_fi": "Kulkureitillä sisäänkäynnille on jyrkkä mäki.",
        "shortage_sv": "På rutten till ingången finns en brant backe.",
        "shortage_en": "The route to the entrance has a steep slope."
    }, {
        "viewpoint_id": "11",
        "shortage_fi": "Sisäänkäynnissä on yli 2 cm korkea kynnys.",
        "shortage_sv": "Vid ingången finns en över 2 cm hög tröskel.",
        "shortage_en": "The entrance has a threshold over 2 cm high."
    }, {
        "viewpoint_id": "11",
        "shortage_fi": "Sisäänkäynnissä on ahdas tuulikaappi.",
        "shortage_sv": "Det finns ett trångt vindfång vid ingången.",
        "shortage_en": "The entrance has a cramped foyer."
    }, {
        "viewpoint_id": "12",
        "shortage_fi": "Esteettömiä autopaikkoja ei ole.",
        "shortage_sv": "Inga p-platser för personer med rörelsehinder.",
        "shortage_en": "No parking places for persons with a disability."
    }, {
        "viewpoint_id": "12",
        "shortage_fi": "Kulkureitti sisäänkäynnille ei ole tasainen.",
        "shortage_sv": "Rutten till ingången är inte jämn.",
        "shortage_en": "The route to the entrance is not even."
    }, {
        "viewpoint_id": "12",
        "shortage_fi": "Kulkureitillä sisäänkäynnille on jyrkkä mäki.",
        "shortage_sv": "På rutten till ingången finns en brant backe.",
        "shortage_en": "The route to the entrance has a steep slope."
    }, {
        "viewpoint_id": "12",
        "shortage_fi": "Sisäänkäynnissä on yli 2 cm korkea kynnys.",
        "shortage_sv": "Vid ingången finns en över 2 cm hög tröskel.",
        "shortage_en": "The entrance has a threshold over 2 cm high."
    }, {
        "viewpoint_id": "12",
        "shortage_fi": "Sisäänkäynnissä on ahdas tuulikaappi.",
        "shortage_sv": "Det finns ett trångt vindfång vid ingången.",
        "shortage_en": "The entrance has a cramped foyer."
    }, {
        "viewpoint_id": "13",
        "shortage_fi": "Kulkureitti sisäänkäynnille ei ole tasainen.",
        "shortage_sv": "Rutten till ingången är inte jämn.",
        "shortage_en": "The route to the entrance is not even."
    }, {
        "viewpoint_id": "13",
        "shortage_fi": "Kulkureitillä sisäänkäynnille on jyrkkä mäki.",
        "shortage_sv": "På rutten till ingången finns en brant backe.",
        "shortage_en": "The route to the entrance has a steep slope."
    }, {
        "viewpoint_id": "13",
        "shortage_fi": "Sisäänkäynnissä on yli 2 cm korkea kynnys.",
        "shortage_sv": "Vid ingången finns en över 2 cm hög tröskel.",
        "shortage_en": "The entrance has a threshold over 2 cm high."
    }, {
        "viewpoint_id": "13",
        "shortage_fi": "Sisäänkäynnissä on ahdas tuulikaappi.",
        "shortage_sv": "Det finns ett trångt vindfång vid ingången.",
        "shortage_en": "The entrance has a cramped foyer."
    }, {
        "viewpoint_id": "21",
        "shortage_fi": "Kulkureitti sisäänkäynnille ei ole tasainen.",
        "shortage_sv": "Rutten till ingången är inte jämn.",
        "shortage_en": "The route to the entrance is not even."
    }, {
        "viewpoint_id": "21",
        "shortage_fi": "Kulkureitillä sisäänkäynnille on jyrkkä mäki.",
        "shortage_sv": "På rutten till ingången finns en brant backe.",
        "shortage_en": "The route to the entrance has a steep slope."
    }, {
        "viewpoint_id": "22",
        "shortage_fi": "Esteettömiä autopaikkoja ei ole.",
        "shortage_sv": "Inga p-platser för personer med rörelsehinder.",
        "shortage_en": "No parking places for persons with a disability."
    }, {
        "viewpoint_id": "22",
        "shortage_fi": "Kulkureitti sisäänkäynnille ei ole tasainen.",
        "shortage_sv": "Rutten till ingången är inte jämn.",
        "shortage_en": "The route to the entrance is not even."
    }, {
        "viewpoint_id": "22",
        "shortage_fi": "Kulkureitillä sisäänkäynnille on jyrkkä mäki.",
        "shortage_sv": "På rutten till ingången finns en brant backe.",
        "shortage_en": "The route to the entrance has a steep slope."
    }, {
        "viewpoint_id": "23",
        "shortage_fi": "Kulkureitti sisäänkäynnille ei ole tasainen.",
        "shortage_sv": "Rutten till ingången är inte jämn.",
        "shortage_en": "The route to the entrance is not even."
    }, {
        "viewpoint_id": "23",
        "shortage_fi": "Kulkureitillä sisäänkäynnille on jyrkkä mäki.",
        "shortage_sv": "På rutten till ingången finns en brant backe.",
        "shortage_en": "The route to the entrance has a steep slope."
    }, {
        "viewpoint_id": "31",
        "shortage_fi": "Kulkureitti sisäänkäynnille ei ole tasainen.",
        "shortage_sv": "Rutten till ingången är inte jämn.",
        "shortage_en": "The route to the entrance is not even."
    }, {
        "viewpoint_id": "31",
        "shortage_fi": "Kulkureitillä sisäänkäynnille on jyrkkä mäki.",
        "shortage_sv": "På rutten till ingången finns en brant backe.",
        "shortage_en": "The route to the entrance has a steep slope."
    }, {
        "viewpoint_id": "31",
        "shortage_fi": "Sisäänkäynnissä on yli 2 cm korkea kynnys.",
        "shortage_sv": "Vid ingången finns en över 2 cm hög tröskel.",
        "shortage_en": "The entrance has a threshold over 2 cm high."
    }, {
        "viewpoint_id": "31",
        "shortage_fi": "Sisäänkäynnissä on ahdas tuulikaappi.",
        "shortage_sv": "Det finns ett trångt vindfång vid ingången.",
        "shortage_en": "The entrance has a cramped foyer."
    }, {
        "viewpoint_id": "32",
        "shortage_fi": "Esteettömiä autopaikkoja ei ole.",
        "shortage_sv": "Inga p-platser för personer med rörelsehinder.",
        "shortage_en": "No parking places for persons with a disability."
    }, {
        "viewpoint_id": "32",
        "shortage_fi": "Kulkureitti sisäänkäynnille ei ole tasainen.",
        "shortage_sv": "Rutten till ingången är inte jämn.",
        "shortage_en": "The route to the entrance is not even."
    }, {
        "viewpoint_id": "32",
        "shortage_fi": "Kulkureitillä sisäänkäynnille on jyrkkä mäki.",
        "shortage_sv": "På rutten till ingången finns en brant backe.",
        "shortage_en": "The route to the entrance has a steep slope."
    }, {
        "viewpoint_id": "32",
        "shortage_fi": "Sisäänkäynnissä on yli 2 cm korkea kynnys.",
        "shortage_sv": "Vid ingången finns en över 2 cm hög tröskel.",
        "shortage_en": "The entrance has a threshold over 2 cm high."
    }, {
        "viewpoint_id": "32",
        "shortage_fi": "Sisäänkäynnissä on ahdas tuulikaappi.",
        "shortage_sv": "Det finns ett trångt vindfång vid ingången.",
        "shortage_en": "The entrance has a cramped foyer."
    }, {
        "viewpoint_id": "33",
        "shortage_fi": "Kulkureitti sisäänkäynnille ei ole tasainen.",
        "shortage_sv": "Rutten till ingången är inte jämn.",
        "shortage_en": "The route to the entrance is not even."
    }, {
        "viewpoint_id": "33",
        "shortage_fi": "Kulkureitillä sisäänkäynnille on jyrkkä mäki.",
        "shortage_sv": "På rutten till ingången finns en brant backe.",
        "shortage_en": "The route to the entrance has a steep slope."
    }, {
        "viewpoint_id": "33",
        "shortage_fi": "Sisäänkäynnissä on yli 2 cm korkea kynnys.",
        "shortage_sv": "Vid ingången finns en över 2 cm hög tröskel.",
        "shortage_en": "The entrance has a threshold over 2 cm high."
    }, {
        "viewpoint_id": "33",
        "shortage_fi": "Sisäänkäynnissä on ahdas tuulikaappi.",
        "shortage_sv": "Det finns ett trångt vindfång vid ingången.",
        "shortage_en": "The entrance has a cramped foyer."
    }, {
        "viewpoint_id": "41",
        "shortage_fi": "Ei puutteita.",
        "shortage_sv": "Inga brister.",
        "shortage_en": "No shortcomings."
    }, {
        "viewpoint_id": "51",
        "shortage_fi": "Sisätilojen kulkureiteillä ei ole liikkumista ohjaavaa pintamateriaalia (tummuus- tai tuntokontrasti).",
        "shortage_sv": "Rutterna inomhus saknar ytmaterial ger anvisningar om hur man tar sig fram (ljushets- eller materialkontrast).",
        "shortage_en": "The indoor routes do not have guiding surface materials (colour or tactile contrast)."
    }, {
        "viewpoint_id": "51",
        "shortage_fi": "Sisätilojen lasiovissa ei ole kontrastimerkintöjä.",
        "shortage_sv": "Det finns inga kontrastmarkeringar på glasdörrarna inomhus.",
        "shortage_en": "The glass doors in the indoor area do not have contrast markings."
    }, {
        "viewpoint_id": "52",
        "shortage_fi": "Sisätilojen kulkureiteillä ei ole liikkumista ohjaavaa pintamateriaalia (tummuus- tai tuntokontrasti).",
        "shortage_sv": "Rutterna inomhus saknar ytmaterial ger anvisningar om hur man tar sig fram (ljushets- eller materialkontrast).",
        "shortage_en": "The indoor routes do not have guiding surface materials (colour or tactile contrast)."
    }, {
        "viewpoint_id": "52",
        "shortage_fi": "Sisätilojen lasiovissa ei ole kontrastimerkintöjä.",
        "shortage_sv": "Det finns inga kontrastmarkeringar på glasdörrarna inomhus.",
        "shortage_en": "The glass doors in the indoor area do not have contrast markings."
    }, {
        "viewpoint_id": "61",
        "shortage_fi": "Ei tiedettyjä puutteita.",
        "shortage_sv": "Inga kända brister.",
        "shortage_en": "No known shortcomings."
    }
]
```
</details>

#### Servicemap Unit
https://api.hel.fi/servicemap/v2/unit/5/

<summary>Results</summary>
<details>

```json
{
    "id": 5,
    "name": {
        "fi": "Päiväkoti Kaunokki",
        "sv": "Päiväkoti Kaunokki",
        "en": "Daycare Kaunokki"
    },
    "accessibility_viewpoints": {
        "00": null,
        "11": "red",
        "12": "red",
        "13": "red",
        "21": "red",
        "22": "red",
        "23": "red",
        "31": "red",
        "32": "red",
        "33": "red",
        "41": "green",
        "51": "red",
        "52": "red",
        "61": null
    },
    "accessibility_shortcoming_count": {
        "rollator": 5,
        "wheelchair": 5,
        "reduced_mobility": 3,
        "visually_impaired": 2
    }
}
```
</details>

#### So what got changed in the data?

Accessibility shortcoming counts:
- **"hearing_aid": null**
  - i.e. explicitly unknown now in output data, wasn't present before in accessibility_shortcoming_count or accessibility.shortcomings
- "rollator": 5
- **"stroller": 0**
  - i.e. explicitly no shortcomings now in output data, wasn't present before in accessibility_shortcoming_count or accessibility.shortcomings
- "wheelchair": 5
- "reduced_mobility": 3
- "visually_impaired": 2

[US-112]: https://helsinkisolutionoffice.atlassian.net/browse/US-112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ