### PR TITLE
LIIKUNTA-27 | feat(graphql): add ontologyTreeIdsOrSet2 query parameter

### DIFF
--- a/graphql/src/datasources/es.ts
+++ b/graphql/src/datasources/es.ts
@@ -183,6 +183,7 @@ class ElasticSearchAPI extends RESTDataSource {
     administrativeDivisionIds?: string[],
     ontologyTreeId?: string,
     ontologyTreeIds?: string[],
+    ontologyTreeIdsOrSet2?: string[],
     ontologyWordIds?: string[],
     providerTypes?: string[],
     serviceOwnerTypes?: string[],
@@ -316,6 +317,10 @@ class ElasticSearchAPI extends RESTDataSource {
       ...buildArrayFilter(
         'links.raw_data.ontologytree_ids_enriched.id',
         ontologyIds
+      ),
+      ...buildArrayFilter(
+        'links.raw_data.ontologytree_ids_enriched.id',
+        ontologyTreeIdsOrSet2 ?? []
       ),
       ...buildArrayFilter(
         'links.raw_data.ontologyword_ids_enriched.id',

--- a/graphql/src/index.ts
+++ b/graphql/src/index.ts
@@ -46,6 +46,7 @@ type UnifiedSearchQuery = {
   administrativeDivisionIds?: string[];
   ontologyTreeId?: string;
   ontologyTreeIds?: string[];
+  ontologyTreeIdsOrSet2?: string[];
   ontologyWordIds?: string[];
   providerTypes?: string[];
   serviceOwnerTypes?: string[];
@@ -98,6 +99,7 @@ const resolvers = {
         administrativeDivisionIds,
         ontologyTreeId,
         ontologyTreeIds,
+        ontologyTreeIdsOrSet2,
         ontologyWordIds,
         providerTypes,
         serviceOwnerTypes,
@@ -139,6 +141,7 @@ const resolvers = {
         administrativeDivisionIds,
         ontologyTreeId,
         ontologyTreeIds,
+        ontologyTreeIdsOrSet2,
         ontologyWordIds,
         providerTypes,
         serviceOwnerTypes,

--- a/graphql/src/schemas/query.ts
+++ b/graphql/src/schemas/query.ts
@@ -106,6 +106,13 @@ export const querySchema = gql`
         ontologyTreeIds: [ID],
 
         """
+        Optional, filter to match only these ontology tree ids,
+        if ontologyTreeIds is also given then it must match separately i.e.
+        at least one ontology tree ID must match in both sets separately.
+        """
+        ontologyTreeIdsOrSet2: [ID],
+
+        """
         Optional, filter to match only these ontology word ids
         """
         ontologyWordIds: [ID],


### PR DESCRIPTION
## Description

### feat(graphql): add ontologyTreeIdsOrSet2 query parameter

ontologyTreeIdsOrSet2 query parameter:
 - "Optional, filter to match only these ontology tree ids,
   if ontologyTreeIds is also given then it must match separately i.e.
   at least one ontology tree ID must match in both sets separately."

refs LIIKUNTA-27

### Tickets 

[LIIKUNTA-27](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-27)

### Manual testing

## Manual testing

- check out PR's branch
- `docker compose up --build`
- `docker exec -it unified-search-sources-1 bash`
  - `python manage.py ingest_data location`
  - Wait 5-10mins for location data import to finish
- query local http://localhost:4000/search GraphQL endpoint with e.g. query for ontology tree IDs 611 and 2221 matching separately

<summary>query for ontology tree IDs 611 and 2221 matching separately</summary>

<details>

```graphql
query unifiedSearch {
  unifiedSearch(
    first: 100
    index: "location"
    q: "*"
    languages: [FINNISH]
    ontologyTreeIds: [611],
    ontologyTreeIdsOrSet2: [2221],
  ) {
    edges {
      cursor
      node {
        venue {
         meta  {id}
          name {
            fi
          }
        }
      }
    }
  }
}
```
</details>

Got the results:
<summary>results</summary>

<details>

```json
{
  "data": {
    "unifiedSearch": {
      "edges": [
        {
          "cursor": "eyJvZmZzZXQiOjF9",
          "node": {
            "venue": {
              "meta": {
                "id": "40158"
              },
              "name": {
                "fi": "Urheiluhallit Vuosaari / Kuntosali 1"
              }
            }
          }
        },
        {
          "cursor": "eyJvZmZzZXQiOjJ9",
          "node": {
            "venue": {
              "meta": {
                "id": "40683"
              },
              "name": {
                "fi": "Urheiluhallit Pasila / Kuntosali"
              }
            }
          }
        },
        {
          "cursor": "eyJvZmZzZXQiOjN9",
          "node": {
            "venue": {
              "meta": {
                "id": "40853"
              },
              "name": {
                "fi": "Urheiluhallit Vuosaari / Kuntosali 2"
              }
            }
          }
        },
        {
          "cursor": "eyJvZmZzZXQiOjR9",
          "node": {
            "venue": {
              "meta": {
                "id": "41318"
              },
              "name": {
                "fi": "Kontulan kuntokellari / Kuntosali"
              }
            }
          }
        },
        {
          "cursor": "eyJvZmZzZXQiOjV9",
          "node": {
            "venue": {
              "meta": {
                "id": "41540"
              },
              "name": {
                "fi": "Liikuntamylly / Kuntosali"
              }
            }
          }
        },
        {
          "cursor": "eyJvZmZzZXQiOjZ9",
          "node": {
            "venue": {
              "meta": {
                "id": "41575"
              },
              "name": {
                "fi": "Helsingin Urheilutalo / Urheiluhallit Kallio / Kuntosali"
              }
            }
          }
        },
        {
          "cursor": "eyJvZmZzZXQiOjd9",
          "node": {
            "venue": {
              "meta": {
                "id": "41996"
              },
              "name": {
                "fi": "Urheiluhallit Siltamäki / Kuntosali"
              }
            }
          }
        },
        {
          "cursor": "eyJvZmZzZXQiOjh9",
          "node": {
            "venue": {
              "meta": {
                "id": "40259"
              },
              "name": {
                "fi": "Oulunkylän liikuntapuisto / Kuntosali"
              }
            }
          }
        }
      ]
    }
  }
}
```
</details>

Venues' ontology tree IDs from `https://api.hel.fi/servicemap/v2/unit/<venue ID>`:
- "id": "[40158](https://api.hel.fi/servicemap/v2/unit/40158/?only=service_nodes&format=json)" -> {"id":40158,"service_nodes":[611,617,2219,2221]}
- "id": "[40259](https://api.hel.fi/servicemap/v2/unit/40259/?only=service_nodes&format=json)" -> {"id":40259,"service_nodes":[611,2219,2221]}
- "id": "[40683](https://api.hel.fi/servicemap/v2/unit/40683/?only=service_nodes&format=json)" -> {"id":40683,"service_nodes":[611,2219,2221]}
- "id": "[40853](https://api.hel.fi/servicemap/v2/unit/40853/?only=service_nodes&format=json)" -> {"id":40853,"service_nodes":[611,617,2219,2221]}
- "id": "[41318](https://api.hel.fi/servicemap/v2/unit/41318/?only=service_nodes&format=json)" -> {"id":41318,"service_nodes":[611,2219,2221]}
- "id": "[41540](https://api.hel.fi/servicemap/v2/unit/41540/?only=service_nodes&format=json)" -> {"id":41540,"service_nodes":[611,617,2219,2221]}
- "id": "[41575](https://api.hel.fi/servicemap/v2/unit/41575/?only=service_nodes&format=json)" -> {"id":41575,"service_nodes":[611,2219,2221]}
- "id": "[41996](https://api.hel.fi/servicemap/v2/unit/41996/?only=service_nodes&format=json)" -> {"id":41996,"service_nodes":[611,2219,2221]}

Venues' ontology tree IDs from `https://www.hel.fi/palvelukarttaws/rest/v4/unit/<venue ID>`:
- "id": "[40158](https://www.hel.fi/palvelukarttaws/rest/v4/unit/40158?format=xml)" -> 
```xml
<unit>
  <id>40158</id>
  <name_fi>Urheiluhallit Vuosaari / Kuntosali 1</name_fi>
  <ontologytree_ids>
    <int>611</int>
    <int>617</int>
    <int>2219</int>
    <int>2221</int>
  </ontologytree_ids>
  ...
</unit>
```
- "id": "[40259](https://www.hel.fi/palvelukarttaws/rest/v4/unit/40259?format=xml)" -> ...
- "id": "[40683](https://www.hel.fi/palvelukarttaws/rest/v4/unit/40683?format=xml)" -> ...
- "id": "[40853](https://www.hel.fi/palvelukarttaws/rest/v4/unit/40853?format=xml)" -> ...
- "id": "[41318](https://www.hel.fi/palvelukarttaws/rest/v4/unit/41318?format=xml)" -> ...
- "id": "[41540](https://www.hel.fi/palvelukarttaws/rest/v4/unit/41540?format=xml)" -> ...
- "id": "[41575](https://www.hel.fi/palvelukarttaws/rest/v4/unit/41575?format=xml)" -> ...
- "id": "[41996](https://www.hel.fi/palvelukarttaws/rest/v4/unit/41996?format=xml)" -> 
```xml
<unit>
  <id>41996</id>
  <name_fi>Urheiluhallit Siltamäki / Kuntosali</name_fi>
  <ontologytree_ids>
    <int>611</int>
    <int>2219</int>
    <int>2221</int>
  </ontologytree_ids>
  ...
</unit>
```

And they all match 611 and 2221. ✅ 

### Related

keywordOrSet* in [LinkedEvents code](https://github.com/City-of-Helsinki/linkedevents/blob/0a5222168ae3bc04ecce055e15b0b6d23b259fd9/events/api.py#L3129-L3136) and related [discussion in PR](https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/206#discussion_r1105855747)

[LIIKUNTA-27]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ