### PR TITLE
fix: fix broken LinkedEvents URLs in review and testing environments

### DIFF
--- a/azure-pipelines-unified-search-sources-review.yml
+++ b/azure-pipelines-unified-search-sources-review.yml
@@ -53,8 +53,8 @@ extends:
   # Django example: azure-pipelines-PROJECTNAME-api-release.yml
   # Drupal example: azure-pipelines-drupal-release.yml
   template: azure-pipelines-unified-search-sources-review.yml@kuva-unified-search-pipelines
-  parameters:
+  #parameters:
     # Application build arguments and config map values as key value pairs.
     # The values here will override the values defined in the kuva-unified-search-pipelines-pipelines repository
-    configMap:
-      EVENT_URL: https://linkedevents.api.hel.fi/v1/event/?start=today
+    #configMap:
+      #EVENT_URL: https://linkedevents.api.test.hel.ninja/v1/event/?start=today

--- a/azure-pipelines-unified-search-sources-test.yml
+++ b/azure-pipelines-unified-search-sources-test.yml
@@ -49,8 +49,8 @@ extends:
   # Django example: azure-pipelines-PROJECTNAME-api-release.yml
   # Drupal example: azure-pipelines-drupal-release.yml
   template: azure-pipelines-unified-search-sources-test.yml@kuva-unified-search-pipelines
-  parameters:
+  #parameters:
     # Application build arguments and config map values as key value pairs.
     # The values here will override the values defined in the kuva-unified-search-pipelines-pipelines repository
-    configMap:
-      EVENT_URL: https://linkedevents.api.hel.fi/v1/event/?start=today
+    #configMap:
+      #EVENT_URL: https://linkedevents.api.test.hel.ninja/v1/event/?start=today


### PR DESCRIPTION
## Description

### fix: fix broken LinkedEvents URLs in review and testing environments

left the commented out URLs for LinkedEvents test environment in
the pipeline files if there's a need to test against the test
environment, alternatively they could be removed completely for clarity