### PR TITLE
US-115 | feat(graphql): type graphql search index with an enumeration for clarity

### DIFF
--- a/graphql/package.json
+++ b/graphql/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "nodemon --ext ts src/index.ts --exec ts-node",
     "transpile": "tsc",
+    "typecheck": "tsc --project ./tsconfig.json --noEmit",
     "serve": "node --max-http-header-size=16000 dist/index.js",
     "test": "jest --watch"
   },

--- a/graphql/src/datasources/es.ts
+++ b/graphql/src/datasources/es.ts
@@ -22,7 +22,7 @@ const ELASTIC_SEARCH_INDICES = [
   ES_LOCATION_INDEX,
 ] as const;
 
-type ElasticSearchIndex = typeof ELASTIC_SEARCH_INDICES[number];
+export type ElasticSearchIndex = typeof ELASTIC_SEARCH_INDICES[number];
 
 const EVENT_SEARCH_RESULT_FIELD = 'event' as const;
 const VENUE_SEARCH_RESULT_FIELD = 'venue' as const;
@@ -225,25 +225,31 @@ class ElasticSearchAPI extends RESTDataSource {
     // Some fields should be boosted / weighted to get more relevant result set
     const searchFieldsBoostMapping = {
       // Normally weighted search fields for different indexes
-      1: (lang: string, index: string) => {
+      1: (lang: ElasticLanguage, index: ElasticSearchIndex) => {
         return (
           {
-            location: [`venue.description.${lang}`],
-            event: [`event.name.${lang}`, `event.description.${lang}`],
+            [ES_LOCATION_INDEX]: [`venue.description.${lang}`],
+            [ES_EVENT_INDEX]: [
+              `event.name.${lang}`,
+              `event.description.${lang}`,
+            ],
           }[index] ?? []
         );
       },
-      3: (lang: string, index: string) => {
+      3: (lang: ElasticLanguage, index: ElasticSearchIndex) => {
         return (
           {
-            location: [`venue.name.${lang}`],
+            [ES_LOCATION_INDEX]: [`venue.name.${lang}`],
           }[index] ?? []
         );
       },
     };
 
     // Ontology fields for different indexes
-    const ontologyFields = (lang: string, index: ElasticSearchIndex) => {
+    const ontologyFields = (
+      lang: ElasticLanguage,
+      index: ElasticSearchIndex
+    ) => {
       if (index === ES_LOCATION_INDEX) {
         return [
           `links.raw_data.ontologyword_ids_enriched.extra_searchwords_${lang}`,

--- a/graphql/src/index.ts
+++ b/graphql/src/index.ts
@@ -22,6 +22,7 @@ import pageInfoResolver from './resolvers/pageInfoResolver';
 import { ConnectionArguments, ConnectionCursorObject } from './types';
 import {
   AccessibilityProfileType,
+  ElasticSearchIndex,
   OrderByDistanceParams,
   OrderByNameParams,
 } from './datasources/es';
@@ -53,7 +54,7 @@ type UnifiedSearchQuery = {
   serviceOwnerTypes?: string[];
   targetGroups?: string[];
   mustHaveReservableResource?: boolean;
-  index?: string;
+  index?: ElasticSearchIndex;
   languages?: string[];
   openAt?: string;
   orderByDistance?: OrderByDistanceParams;

--- a/graphql/src/schemas/query.ts
+++ b/graphql/src/schemas/query.ts
@@ -73,6 +73,15 @@ export const querySchema = gql`
     order: SortOrder = ASCENDING
   }
 
+  enum UnifiedSearchIndex {
+    administrative_division
+    helsinki_common_administrative_division
+    ontology_tree
+    ontology_word
+    event
+    location
+  }
+
   type Query {
     unifiedSearch(
         """
@@ -124,7 +133,7 @@ export const querySchema = gql`
         """
         Optional search index.
         """
-        index: String,
+        index: UnifiedSearchIndex,
 
         """
         Optional pagination variable, match results after this cursor.
@@ -188,7 +197,7 @@ export const querySchema = gql`
       """
       Optional search index.
       """
-      index: String
+      index: UnifiedSearchIndex
 
       """
       Optional result size.


### PR DESCRIPTION
## Description

### feat(graphql): type graphql search index with an enumeration for clarity

also:
 - add "typecheck" command to graphql package.json for checking
   Typescript types
 - add more typings to the use of indices

refs US-115

## Tickets

[US-115](https://helsinkisolutionoffice.atlassian.net/browse/US-115)

[US-115]: https://helsinkisolutionoffice.atlassian.net/browse/US-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ