### PR TITLE
feat(search): use a "simple query string" query

### DIFF
--- a/graphql/src/datasources/es/index.ts
+++ b/graphql/src/datasources/es/index.ts
@@ -137,7 +137,7 @@ class ElasticSearchAPI extends RESTDataSource {
           // Don't map empty field sets to query
           .filter(([, searchFields]) => searchFields(language, index).length)
           .map(([boost, searchFields]) => ({
-            query_string: {
+            simple_query_string: {
               query: text,
               boost,
               fields: searchFields(language, index),


### PR DESCRIPTION
LIIKUNTA-255. Use `simple_query_string ` query instead of `query_string`.

There are some reserved special characters that needs to be escaped,
if the query_string query is used.
The characters are `+ - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /`.
Reference: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters.

By using the `simple_query_string` query, the escaping for the characters  is not that much needed. There are some special characters that have a special meaning to act as an operator,
but the code should not fail because of any parsing issues anymore.

```
The simple_query_string query supports the following operators:

+ signifies AND operation
| signifies OR operation
- negates a single token
" wraps a number of tokens to signify a phrase for searching
* at the end of a term signifies a prefix query
( and ) signify precedence
~N after a word signifies edit distance (fuzziness)
~N after a phrase signifies slop amount
```

Reference: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#query-dsl-simple-query-string-query and https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#simple-query-string-syntax

----

### How to test


Use the following request to test whether or not the Unified-Search server responses with an error code or with an reasonable result.

```
POST http://localhost:4000/search HTTP/1.1
content-type: application/json

{
    "query": "query SearchList($text: String, $first: Int, $after: String, $language: UnifiedSearchLanguage!, $administrativeDivisionIds: [ID!], $ontologyTreeIdOrSets: [[ID!]!], $ontologyWordIdOrSets: [[ID!]!], $providerTypes: [ProviderType], $serviceOwnerTypes: [ServiceOwnerType], $targetGroups: [TargetGroup], $openAt: String, $orderByDistance: OrderByDistance, $orderByName: OrderByName, $orderByAccessibilityProfile: AccessibilityProfile, $showAccessibilityShortcomingsFor: AccessibilityProfile, $includeHaukiFields: Boolean = true) {\n  unifiedSearch(\n    text: $text\n    index: location\n    first: $first\n    after: $after\n    languages: [$language]\n    administrativeDivisionIds: $administrativeDivisionIds\n    ontologyTreeIdOrSets: $ontologyTreeIdOrSets\n    ontologyWordIdOrSets: $ontologyWordIdOrSets\n    providerTypes: $providerTypes\n    serviceOwnerTypes: $serviceOwnerTypes\n    targetGroups: $targetGroups\n    openAt: $openAt\n    orderByDistance: $orderByDistance\n    orderByName: $orderByName\n    orderByAccessibilityProfile: $orderByAccessibilityProfile\n  ) {\n    count\n    pageInfo {\n      endCursor\n      hasNextPage\n      __typename\n    }\n    edges {\n      node {\n        venue {\n          meta {\n            id\n            __typename\n          }\n          name {\n            fi\n            sv\n            en\n            __typename\n          }\n          description {\n            fi\n            __typename\n          }\n          images {\n            url\n            __typename\n          }\n          openingHours @include(if: $includeHaukiFields) {\n            today {\n              startTime\n              endTime\n              endTimeOnNextDay\n              fullDay\n              resourceState\n              __typename\n            }\n            data {\n              date\n              times {\n                startTime\n                endTime\n                endTimeOnNextDay\n                fullDay\n                resourceState\n                __typename\n              }\n              __typename\n            }\n            __typename\n          }\n          location {\n            address {\n              streetAddress {\n                fi\n                sv\n                en\n                __typename\n              }\n              postalCode\n              city {\n                fi\n                sv\n                en\n                __typename\n              }\n              __typename\n            }\n            geoLocation {\n              geometry {\n                coordinates\n                __typename\n              }\n              __typename\n            }\n            __typename\n          }\n          ontologyWords {\n            id\n            label {\n              fi\n              sv\n              en\n              __typename\n            }\n            __typename\n          }\n          serviceOwner {\n            name {\n              fi\n              sv\n              en\n              __typename\n            }\n            providerType\n            type\n            __typename\n          }\n          targetGroups\n          accessibilityShortcomingFor(profile: $showAccessibilityShortcomingsFor) {\n            profile\n            count\n            __typename\n          }\n          __typename\n        }\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}",
    "variables":{
        "includeHaukiFields":false,
        "language":"FINNISH",
        "text":"naapuri / asukastila",
        "ontologyTreeIdOrSets":[["551"]],
        "ontologyWordIdOrSets":[],
        "administrativeDivisionIds":["ocd-division/country:fi/kunta:helsinki"],
        "openAt":null,
        "after":"",
        "first":10
    }
}

```

To test the special characters operations, use the special characters that are listed above inside the text-variable.

A local isntance of Unified-search can be ran with `docker compose up --build`. Check the README if you don't have any data indexed yet.