### PR TITLE
feat(search): use a "simple query string" query

### DIFF
--- a/graphql/src/datasources/es/index.ts
+++ b/graphql/src/datasources/es/index.ts
@@ -137,7 +137,7 @@ class ElasticSearchAPI extends RESTDataSource {
           // Don't map empty field sets to query
           .filter(([, searchFields]) => searchFields(language, index).length)
           .map(([boost, searchFields]) => ({
-            query_string: {
+            simple_query_string: {
               query: text,
               boost,
               fields: searchFields(language, index),


### PR DESCRIPTION
LIIKUNTA-255. Use `simple_query_string ` query instead of `query_string`.

There are some reserved special characters that needs to be escaped,
if the query_string query is used.
The characters are `+ - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /`.
Reference: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters.

By using the `simple_query_string` query, the escaping for the characters  is not that much needed. There are some special characters that have a special meaning to act as an operator,
but the code should not fail because of any parsing issues anymore.

```
The simple_query_string query supports the following operators:

+ signifies AND operation
| signifies OR operation
- negates a single token
" wraps a number of tokens to signify a phrase for searching
* at the end of a term signifies a prefix query
( and ) signify precedence
~N after a word signifies edit distance (fuzziness)
~N after a phrase signifies slop amount
```

Reference: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#query-dsl-simple-query-string-query and https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#simple-query-string-syntax
