### PR TITLE
Exact matches should be higher in relevance

### DIFF
--- a/graphql/src/datasources/es/api/getQueryResults/constants.ts
+++ b/graphql/src/datasources/es/api/getQueryResults/constants.ts
@@ -1,9 +1,12 @@
-import type { ElasticLanguage } from '../../../../types';
+import type { ElasticLanguage, TranslatableField } from '../../../../types';
 import { ES_EVENT_INDEX, ES_LOCATION_INDEX } from '../../constants';
 import type { ElasticSearchIndex } from '../../types';
 
 // Some fields should be boosted / weighted to get more relevant result set
-export const searchFieldsBoostMapping = {
+export const searchFieldsBoostMapping: Record<
+  string | number,
+  (lang: ElasticLanguage, index: ElasticSearchIndex) => TranslatableField[]
+> = {
   // Normally weighted search fields for different indexes
   1: (lang: ElasticLanguage, index: ElasticSearchIndex) => {
     return (

--- a/graphql/src/datasources/es/api/getQueryResults/getQueryResults.ts
+++ b/graphql/src/datasources/es/api/getQueryResults/getQueryResults.ts
@@ -2,24 +2,17 @@ import { DEFAULT_ELASTIC_LANGUAGE } from '../../../../types';
 import { ES_DEFAULT_INDEX } from '../../constants';
 import { type ElasticSearchAPI } from '../..';
 import type { GetQueryResultsProps } from './types';
-import { getOntologyFields, sortQuery } from './utils';
+import { getDefaultBoolQuery, getOntologyFields, sortQuery } from './utils';
 import { filterQuery } from './utils/filterQuery';
 import { GraphQlToElasticLanguageMap } from '../../../../constants';
-import {
-  QueryType,
-  getDefaultQueryForQueryType,
-} from './utils/getDefaultQuery';
 
 function createQuery({
   index = ES_DEFAULT_INDEX,
   languages = Object.values(GraphQlToElasticLanguageMap),
   text,
   ontology,
-  type = QueryType.MatchBoolPrefix,
-}: Pick<GetQueryResultsProps, 'index' | 'languages' | 'text' | 'ontology'> & {
-  type?: QueryType;
-}) {
-  const query = getDefaultQueryForQueryType(type)({ index, languages, text });
+}: Pick<GetQueryResultsProps, 'index' | 'languages' | 'text' | 'ontology'>) {
+  const query = getDefaultBoolQuery({ index, languages, text });
   // Resolve ontology
   if (ontology) {
     const ontologyMatchers = languages.reduce(

--- a/graphql/src/datasources/es/api/getQueryResults/getQueryResults.ts
+++ b/graphql/src/datasources/es/api/getQueryResults/getQueryResults.ts
@@ -2,9 +2,10 @@ import { DEFAULT_ELASTIC_LANGUAGE } from '../../../../types';
 import { ES_DEFAULT_INDEX } from '../../constants';
 import { type ElasticSearchAPI } from '../..';
 import type { GetQueryResultsProps } from './types';
-import { getDefaultBoolQuery, getOntologyFields, sortQuery } from './utils';
+import { getDefaultBoolQuery, sortQuery } from './utils';
 import { filterQuery } from './utils/filterQuery';
 import { GraphQlToElasticLanguageMap } from '../../../../constants';
+import { getOntologyQuery } from './utils/getOntologyQuery';
 
 function createQuery({
   index = ES_DEFAULT_INDEX,
@@ -12,36 +13,12 @@ function createQuery({
   text,
   ontology,
 }: Pick<GetQueryResultsProps, 'index' | 'languages' | 'text' | 'ontology'>) {
-  const query = getDefaultBoolQuery({ index, languages, text });
-  // Resolve ontology
   if (ontology) {
-    const ontologyMatchers = languages.reduce(
-      (acc, language) => ({
-        ...acc,
-        [language]: {
-          multi_match: {
-            query: ontology,
-            fields: getOntologyFields(language, index),
-          },
-        },
-      }),
-      {}
-    );
-
-    return {
-      query: {
-        bool: {
-          should: [
-            ...query.query.bool.should,
-            ...languages.map((language) => ({
-              bool: { must: [ontologyMatchers[language]] },
-            })),
-          ],
-        },
-      },
-    };
+    // Resolve ontology
+    // NOTE: This query has not been in use anymore in the events-helsinki-monorepo. It was earlier used with auto suggest menu.
+    return getOntologyQuery({ index, languages, ontology });
   }
-  return query;
+  return getDefaultBoolQuery({ index, languages, text });
 }
 
 function queryBuilder({

--- a/graphql/src/datasources/es/api/getQueryResults/getQueryResults.ts
+++ b/graphql/src/datasources/es/api/getQueryResults/getQueryResults.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_ELASTIC_LANGUAGE } from '../../../../types';
-import { ES_DEFAULT_INDEX } from '../../constants';
+import { ES_DEFAULT_INDEX, SEARCH_ALL_SPECIAL_CHAR } from '../../constants';
 import { type ElasticSearchAPI } from '../..';
 import type { GetQueryResultsProps } from './types';
 import { getDefaultBoolQuery, sortQuery } from './utils';
@@ -13,6 +13,16 @@ function createQuery({
   text,
   ontology,
 }: Pick<GetQueryResultsProps, 'index' | 'languages' | 'text' | 'ontology'>) {
+  if (text === SEARCH_ALL_SPECIAL_CHAR) {
+    return {
+      query: {
+        bool: {
+          should: [{ query_string: { query: SEARCH_ALL_SPECIAL_CHAR } }],
+        },
+      },
+    };
+  }
+
   if (ontology) {
     // Resolve ontology
     // NOTE: This query has not been in use anymore in the events-helsinki-monorepo. It was earlier used with auto suggest menu.

--- a/graphql/src/datasources/es/api/getQueryResults/types.ts
+++ b/graphql/src/datasources/es/api/getQueryResults/types.ts
@@ -1,4 +1,4 @@
-import type { ElasticLanguage } from '../../../../types';
+import type { ElasticLanguage, TranslatableField } from '../../../../types';
 import type {
   AccessibilityProfileType,
   ElasticSearchIndex,
@@ -40,3 +40,14 @@ export type QueryResultFilterProps = Pick<
   | 'mustHaveReservableResource'
   | 'openAt'
 >;
+
+export type QueryFilterClauses = {
+  [key in TranslatableField]?: {
+    query: string;
+  } & Partial<{
+    boost?: number | string;
+    type?: string;
+    operator?: string;
+    fuzziness?: string;
+  }>;
+};

--- a/graphql/src/datasources/es/api/getQueryResults/utils/getDefaultQuery.ts
+++ b/graphql/src/datasources/es/api/getQueryResults/utils/getDefaultQuery.ts
@@ -1,44 +1,227 @@
 import { GraphQlToElasticLanguageMap } from '../../../../../constants';
+import type { ElasticLanguage, TranslatableField } from '../../../../../types';
 import { escapeQuery } from '../../../../../utils';
 import { ES_DEFAULT_INDEX, SEARCH_ALL_SPECIAL_CHAR } from '../../../constants';
 import { searchFieldsBoostMapping } from '../constants';
-import type { GetQueryResultsProps } from '../types';
+import type { GetQueryResultsProps, QueryFilterClauses } from '../types';
 
 const getQueryString = (text?: string) =>
   text && text !== SEARCH_ALL_SPECIAL_CHAR
     ? escapeQuery(text)
     : SEARCH_ALL_SPECIAL_CHAR;
 
-export function getDefaultQuery({
+type DefaultBoolQueryClausesType =
+  | {
+      match_bool_prefix: {
+        [key in TranslatableField]?: QueryFilterClauses;
+      };
+    }
+  | {
+      match_phrase: {
+        [key in TranslatableField]?: QueryFilterClauses;
+      };
+    };
+
+type DefaultQueryStringQueryClausesType = {
+  query_string: QueryFilterClauses & { fields: TranslatableField[] };
+};
+
+type DefaultBoolQueryClausesAccumulatorType = {
+  [key in ElasticLanguage]?: DefaultBoolQueryClausesType;
+};
+
+type DefaultQueryStringQueryClausesAccumulatorType = {
+  [key in ElasticLanguage]?: DefaultQueryStringQueryClausesType;
+};
+
+/**
+ * @returns An ElasticSearch query object. Example:
+ * ```
+ * { "query": {"bool": { "should": [
+ *  {
+ *    "match_bool_prefix": {
+ *      "venue.description.fi": {
+ *        "query": "Itäkeskuksen uimahalli / Kuntosali",
+ *        "operator": "or",
+ *        "fuzziness": "AUTO",
+ *        "boost": "1"
+ *      }
+ *    }
+ *  },
+ *  {
+ *    "match_bool_prefix": {
+ *      "venue.name.fi": {
+ *        "query": "Itäkeskuksen uimahalli / Kuntosali",
+ *        "operator": "or",
+ *        "fuzziness": "AUTO",
+ *        "boost": "3"
+ *      }
+ *    }
+ *  },
+ *  {
+ *    "match_phrase": {
+ *      "venue.description.fi": {
+ *        "query": "Itäkeskuksen uimahalli / Kuntosali",
+ *        "boost": 2
+ *      }
+ *    }
+ *  },
+ *  {
+ *    "match_phrase": {
+ *      "venue.name.fi": {
+ *        "query": "Itäkeskuksen uimahalli / Kuntosali",
+ *        "boost": 6
+ *      }
+ *    }
+ *  }
+ * ]}}}
+ * ```
+ * */
+export function getDefaultBoolQuery({
   index = ES_DEFAULT_INDEX,
   languages = Object.values(GraphQlToElasticLanguageMap),
   text,
 }: Pick<GetQueryResultsProps, 'index' | 'languages' | 'text'>) {
-  // Default query is to search the same thing in every language
-  return languages.reduce(
-    (acc, language) => ({
-      ...acc,
-      [language]: Object.entries(searchFieldsBoostMapping)
-        // Don't map empty field sets to query
-        .filter(([, searchFields]) => searchFields(language, index).length)
-        .map(([boost, searchFields]) => ({
-          // You can use the `query_string` query to create a complex search
-          // that includes wildcard characters,
-          // searches across multiple fields, and more.
-          // While versatile, the query is strict and
-          // returns an error if the query string includes any invalid syntax.
-          // See: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html.
-          query_string: {
-            // Escape the query string so the special chars are not acting as operators.
-            query: getQueryString(text),
-            // Creates a match_bool_prefix query on each field and combines the _score from each field.
-            // See: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#type-bool-prefix.
-            type: 'bool_prefix',
-            boost,
-            fields: searchFields(language, index),
-          },
-        })),
-    }),
-    {}
-  );
+  const should = Object.values(
+    languages.reduce(
+      (acc: DefaultBoolQueryClausesAccumulatorType, language) => ({
+        ...acc,
+        [language]: [
+          ...Object.entries(searchFieldsBoostMapping).map(
+            ([boost, searchFields]) => ({
+              match_bool_prefix: {
+                ...searchFields(language, index).reduce<{
+                  [key in TranslatableField]?: QueryFilterClauses;
+                }>(
+                  (queries, queryField) => ({
+                    ...queries,
+                    [queryField]: {
+                      query: text,
+                      operator: 'or',
+                      fuzziness: 'AUTO',
+                      boost,
+                    },
+                  }),
+                  {}
+                ),
+              },
+            })
+          ),
+          ...Object.entries(searchFieldsBoostMapping).map(
+            ([boost, searchFields]) => ({
+              match_phrase: {
+                ...searchFields(language, index).reduce<{
+                  [key in TranslatableField]?: QueryFilterClauses;
+                }>(
+                  (queries, queryField) => ({
+                    ...queries,
+                    [queryField]: {
+                      query: text,
+                      boost: parseInt(boost) * 2,
+                    },
+                  }),
+                  {}
+                ),
+              },
+            })
+          ),
+        ],
+      }),
+      {}
+    )
+  ).flat();
+  return {
+    query: {
+      bool: {
+        should,
+      },
+    },
+  };
+}
+
+/**
+ * @deprecated Use getDefaultBoolQuery instead.
+ * @returns An ElasticSearch query object. Example:
+ * ```
+ * { "query": { "bool": { "should": [
+ *   {
+ *     "query_string": {
+ *       "query": "Itäkeskuksen uimahalli \\\\/ Kuntosali",
+ *       "type": "bool_prefix",
+ *       "boost": "1",
+ *       "fields": ["venue.description.fi"]
+ *     }
+ *   },
+ *   {
+ *     "query_string": {
+ *       "query": "Itäkeskuksen uimahalli \\\\/ Kuntosali",
+ *       "type": "bool_prefix",
+ *       "boost": "3",
+ *       "fields": ["venue.name.fi"]
+ *     }
+ *   }
+ * ]}}}
+ * ```
+ */
+export function getDefaultQueryStringQuery({
+  index = ES_DEFAULT_INDEX,
+  languages = Object.values(GraphQlToElasticLanguageMap),
+  text,
+}: Pick<GetQueryResultsProps, 'index' | 'languages' | 'text'>) {
+  const should = Object.values(
+    languages.reduce(
+      (acc: DefaultQueryStringQueryClausesAccumulatorType, language) => ({
+        ...acc,
+        [language]: Object.entries(searchFieldsBoostMapping)
+          // Don't map empty field sets to query
+          .filter(([, searchFields]) => searchFields(language, index).length)
+          .map(([boost, searchFields]) => ({
+            // You can use the `query_string` query to create a complex search
+            // that includes wildcard characters,
+            // searches across multiple fields, and more.
+            // While versatile, the query is strict and
+            // returns an error if the query string includes any invalid syntax.
+            // See: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html.
+            query_string: {
+              // Escape the query string so the special chars are not acting as operators.
+              query: getQueryString(text),
+              // Creates a match_bool_prefix query on each field and combines the _score from each field.
+              // See: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#type-bool-prefix.
+              type: 'bool_prefix',
+              boost,
+              fields: searchFields(language, index),
+            },
+          })),
+      }),
+      {}
+    )
+  ).flat();
+  return {
+    query: {
+      bool: {
+        should,
+      },
+    },
+  };
+}
+
+export enum QueryType {
+  MatchBoolPrefix = 'match_bool_prefix',
+  QueryString = 'query_string',
+}
+
+const defaultQueryForType: Record<
+  QueryType,
+  ({
+    index,
+    languages,
+    text,
+  }: Pick<GetQueryResultsProps, 'index' | 'languages' | 'text'>) => any
+> = {
+  [QueryType.MatchBoolPrefix]: getDefaultBoolQuery,
+  [QueryType.QueryString]: getDefaultQueryStringQuery,
+};
+
+export function getDefaultQueryForQueryType(type: QueryType) {
+  return defaultQueryForType[type];
 }

--- a/graphql/src/datasources/es/api/getQueryResults/utils/getDefaultQuery.ts
+++ b/graphql/src/datasources/es/api/getQueryResults/utils/getDefaultQuery.ts
@@ -1,14 +1,8 @@
 import { GraphQlToElasticLanguageMap } from '../../../../../constants';
 import type { ElasticLanguage, TranslatableField } from '../../../../../types';
-import { escapeQuery } from '../../../../../utils';
-import { ES_DEFAULT_INDEX, SEARCH_ALL_SPECIAL_CHAR } from '../../../constants';
+import { ES_DEFAULT_INDEX } from '../../../constants';
 import { searchFieldsBoostMapping } from '../constants';
 import type { GetQueryResultsProps, QueryFilterClauses } from '../types';
-
-const getQueryString = (text?: string) =>
-  text && text !== SEARCH_ALL_SPECIAL_CHAR
-    ? escapeQuery(text)
-    : SEARCH_ALL_SPECIAL_CHAR;
 
 type DefaultBoolQueryClausesType =
   | {
@@ -22,16 +16,8 @@ type DefaultBoolQueryClausesType =
       };
     };
 
-type DefaultQueryStringQueryClausesType = {
-  query_string: QueryFilterClauses & { fields: TranslatableField[] };
-};
-
 type DefaultBoolQueryClausesAccumulatorType = {
   [key in ElasticLanguage]?: DefaultBoolQueryClausesType;
-};
-
-type DefaultQueryStringQueryClausesAccumulatorType = {
-  [key in ElasticLanguage]?: DefaultQueryStringQueryClausesType;
 };
 
 /**
@@ -137,91 +123,4 @@ export function getDefaultBoolQuery({
       },
     },
   };
-}
-
-/**
- * @deprecated Use getDefaultBoolQuery instead.
- * @returns An ElasticSearch query object. Example:
- * ```
- * { "query": { "bool": { "should": [
- *   {
- *     "query_string": {
- *       "query": "Itäkeskuksen uimahalli \\\\/ Kuntosali",
- *       "type": "bool_prefix",
- *       "boost": "1",
- *       "fields": ["venue.description.fi"]
- *     }
- *   },
- *   {
- *     "query_string": {
- *       "query": "Itäkeskuksen uimahalli \\\\/ Kuntosali",
- *       "type": "bool_prefix",
- *       "boost": "3",
- *       "fields": ["venue.name.fi"]
- *     }
- *   }
- * ]}}}
- * ```
- */
-export function getDefaultQueryStringQuery({
-  index = ES_DEFAULT_INDEX,
-  languages = Object.values(GraphQlToElasticLanguageMap),
-  text,
-}: Pick<GetQueryResultsProps, 'index' | 'languages' | 'text'>) {
-  const should = Object.values(
-    languages.reduce(
-      (acc: DefaultQueryStringQueryClausesAccumulatorType, language) => ({
-        ...acc,
-        [language]: Object.entries(searchFieldsBoostMapping)
-          // Don't map empty field sets to query
-          .filter(([, searchFields]) => searchFields(language, index).length)
-          .map(([boost, searchFields]) => ({
-            // You can use the `query_string` query to create a complex search
-            // that includes wildcard characters,
-            // searches across multiple fields, and more.
-            // While versatile, the query is strict and
-            // returns an error if the query string includes any invalid syntax.
-            // See: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html.
-            query_string: {
-              // Escape the query string so the special chars are not acting as operators.
-              query: getQueryString(text),
-              // Creates a match_bool_prefix query on each field and combines the _score from each field.
-              // See: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#type-bool-prefix.
-              type: 'bool_prefix',
-              boost,
-              fields: searchFields(language, index),
-            },
-          })),
-      }),
-      {}
-    )
-  ).flat();
-  return {
-    query: {
-      bool: {
-        should,
-      },
-    },
-  };
-}
-
-export enum QueryType {
-  MatchBoolPrefix = 'match_bool_prefix',
-  QueryString = 'query_string',
-}
-
-const defaultQueryForType: Record<
-  QueryType,
-  ({
-    index,
-    languages,
-    text,
-  }: Pick<GetQueryResultsProps, 'index' | 'languages' | 'text'>) => any
-> = {
-  [QueryType.MatchBoolPrefix]: getDefaultBoolQuery,
-  [QueryType.QueryString]: getDefaultQueryStringQuery,
-};
-
-export function getDefaultQueryForQueryType(type: QueryType) {
-  return defaultQueryForType[type];
 }

--- a/graphql/src/datasources/es/api/getQueryResults/utils/getOntologyQuery.ts
+++ b/graphql/src/datasources/es/api/getQueryResults/utils/getOntologyQuery.ts
@@ -1,0 +1,38 @@
+import { GraphQlToElasticLanguageMap } from '../../../../../constants';
+import { ES_DEFAULT_INDEX } from '../../../constants';
+import type { GetQueryResultsProps } from '../types';
+import { getOntologyFields } from './getOntologyFields';
+
+/** @deprecated Deprecated as unused. */
+export function getOntologyQuery({
+  index = ES_DEFAULT_INDEX,
+  languages = Object.values(GraphQlToElasticLanguageMap),
+  ontology,
+}: Pick<GetQueryResultsProps, 'index' | 'languages' | 'ontology'>) {
+  const ontologyMatchers = languages.reduce(
+    (acc, language) => ({
+      ...acc,
+      [language]: {
+        multi_match: {
+          query: ontology,
+          fields: getOntologyFields(language, index),
+        },
+      },
+    }),
+    {}
+  );
+
+  return {
+    query: {
+      bool: {
+        should: [
+          ...Object.values(
+            languages.map((language) => ({
+              bool: { must: [ontologyMatchers[language]] },
+            }))
+          ).flat(),
+        ],
+      },
+    },
+  };
+}

--- a/graphql/src/datasources/es/api/getQueryResults/utils/index.ts
+++ b/graphql/src/datasources/es/api/getQueryResults/utils/index.ts
@@ -1,4 +1,4 @@
 export { getOntologyFields } from './getOntologyFields';
-export { getDefaultQuery } from './getDefaultQuery';
 export { filterQuery, getFilters } from './filterQuery';
 export { sortQuery } from './sortQuery';
+export * from './getDefaultQuery';

--- a/graphql/src/types.ts
+++ b/graphql/src/types.ts
@@ -27,3 +27,12 @@ export type ElasticLanguage =
   (typeof GraphQlToElasticLanguageMap)[keyof typeof GraphQlToElasticLanguageMap];
 
 export const DEFAULT_ELASTIC_LANGUAGE: ElasticLanguage = 'fi';
+
+export type SearchableFields =
+  | 'venue.name'
+  | 'venue.description'
+  | 'event.name'
+  | 'event.description';
+
+export type TranslatableField<T extends string = SearchableFields> =
+  `${T}.${ElasticLanguage}`;


### PR DESCRIPTION
US-123
Use bool-query with `match_bool_prefix` and `match_phrase` instead of `query_string` query.

Add a bool-query to replace the query_string-query,
since it is simpler and does not need any special care for input.

Add a `match_phrase` query on side of `match_bool_prefix`
to give higher score for "exact matches".

Add a new query function on besides of the old 
`query_string` implementation, just to make the future development easier, if we go back to query string.

Example (tested): When searching with a text-parameter set as 
"Itäkeskuksen uimahalli / Kuntosali",  it returns 
the exact match as first. The result set is a following 
(only name fields included):
1. Itäkeskuksen uimahalli / Kuntosali
2. Itäkeskuksen uimahalli
3. Itäkeskuksen uimahalli / Liikuntasali
4. Itäkeskuksen palvelutalo

----

NOTE: This PR uses https://github.com/City-of-Helsinki/unified-search/pull/136 as a base, so it needs to be merged first.