### PR TITLE
feat(graphql): include ontologies in default search query

### DIFF
--- a/graphql/src/datasources/es/api/getQueryResults/utils/getDefaultQuery.ts
+++ b/graphql/src/datasources/es/api/getQueryResults/utils/getDefaultQuery.ts
@@ -3,6 +3,7 @@ import type { ElasticLanguage, TranslatableField } from '../../../../../types';
 import { ES_DEFAULT_INDEX } from '../../../constants';
 import { searchFieldsBoostMapping } from '../constants';
 import type { GetQueryResultsProps, QueryFilterClauses } from '../types';
+import { getOntologyMatchers } from './getOntologyQuery';
 
 type DefaultBoolQueryClausesType =
   | {
@@ -21,45 +22,131 @@ type DefaultBoolQueryClausesAccumulatorType = {
 };
 
 /**
+ * Search from names and titles, etc, using `match_bool_prefix`.
+ */
+const searchWithBoolPrefix = ({
+  language,
+  index,
+  text,
+}: Pick<GetQueryResultsProps, 'index' | 'text'> & {
+  language: ElasticLanguage;
+}) => {
+  return Object.entries(searchFieldsBoostMapping).map(
+    ([boost, searchFields]) => ({
+      match_bool_prefix: {
+        ...searchFields(language, index).reduce<{
+          [key in TranslatableField]?: QueryFilterClauses;
+        }>(
+          (queries, queryField) => ({
+            ...queries,
+            [queryField]: {
+              query: text,
+              operator: 'or',
+              fuzziness: 'AUTO',
+              boost,
+            },
+          }),
+          {}
+        ),
+      },
+    })
+  );
+};
+
+/**
+ * Search from the ontology fields using `multi_match`.
+ */
+const searchWithOntology = ({
+  language,
+  index,
+  text,
+}: Pick<GetQueryResultsProps, 'index' | 'text'> & {
+  language: ElasticLanguage;
+}) => {
+  return getOntologyMatchers({
+    languages: [language],
+    index,
+    query: text,
+  })[language];
+};
+
+/**
+ * Search from names and titles, etc, using `match_phrase`.
+ * When searching with a phrase and boosting the score result for them,
+ * the exact results will be higher in the relevance.
+ */
+const searchWithPhrase = ({
+  language,
+  index,
+  text,
+}: Pick<GetQueryResultsProps, 'index' | 'text'> & {
+  language: ElasticLanguage;
+}) => {
+  return Object.entries(searchFieldsBoostMapping).map(
+    ([boost, searchFields]) => ({
+      match_phrase: {
+        ...searchFields(language, index).reduce<{
+          [key in TranslatableField]?: QueryFilterClauses;
+        }>(
+          (queries, queryField) => ({
+            ...queries,
+            [queryField]: {
+              query: text,
+              boost: parseInt(boost) * 2,
+            },
+          }),
+          {}
+        ),
+      },
+    })
+  );
+};
+
+/**
  * @returns An ElasticSearch query object. Example:
  * ```
  * { "query": {"bool": { "should": [
- *  {
- *    "match_bool_prefix": {
- *      "venue.description.fi": {
- *        "query": "Itäkeskuksen uimahalli / Kuntosali",
- *        "operator": "or",
- *        "fuzziness": "AUTO",
- *        "boost": "1"
- *      }
- *    }
- *  },
- *  {
- *    "match_bool_prefix": {
- *      "venue.name.fi": {
- *        "query": "Itäkeskuksen uimahalli / Kuntosali",
- *        "operator": "or",
- *        "fuzziness": "AUTO",
- *        "boost": "3"
- *      }
- *    }
- *  },
- *  {
- *    "match_phrase": {
- *      "venue.description.fi": {
- *        "query": "Itäkeskuksen uimahalli / Kuntosali",
- *        "boost": 2
- *      }
- *    }
- *  },
- *  {
- *    "match_phrase": {
- *      "venue.name.fi": {
- *        "query": "Itäkeskuksen uimahalli / Kuntosali",
- *        "boost": 6
- *      }
- *    }
- *  }
+ *   {
+ *     "match_bool_prefix": {
+ *       "venue.description.fi": {
+ *         "query": "*",
+ *         "operator": "or",
+ *         "fuzziness": "AUTO",
+ *         "boost": "1"
+ *       }
+ *     }
+ *   },
+ *   {
+ *     "match_bool_prefix": {
+ *       "venue.name.fi": {
+ *         "query": "*",
+ *         "operator": "or",
+ *         "fuzziness": "AUTO",
+ *         "boost": "3"
+ *       }
+ *     }
+ *   },
+ *   {
+ *     "match_phrase": {
+ *       "venue.description.fi": { "query": "*", "boost": 2 }
+ *     }
+ *   },
+ *   {
+ *     "match_phrase": {
+ *       "venue.name.fi": { "query": "*", "boost": 6 }
+ *     }
+ *   },
+ *   {
+ *     "multi_match": {
+ *       "query": "*",
+ *       "fields": [
+ *         "links.raw_data.ontologyword_ids_enriched.extra_searchwords_fi",
+ *         "links.raw_data.ontologyword_ids_enriched.ontologyword_fi",
+ *         "links.raw_data.ontologytree_ids_enriched.name_fi",
+ *         "links.raw_data.ontologytree_ids_enriched.extra_searchwords_fi"
+ *       ]
+ *     }
+ *   }
  * ]}}}
  * ```
  * */
@@ -73,44 +160,9 @@ export function getDefaultBoolQuery({
       (acc: DefaultBoolQueryClausesAccumulatorType, language) => ({
         ...acc,
         [language]: [
-          ...Object.entries(searchFieldsBoostMapping).map(
-            ([boost, searchFields]) => ({
-              match_bool_prefix: {
-                ...searchFields(language, index).reduce<{
-                  [key in TranslatableField]?: QueryFilterClauses;
-                }>(
-                  (queries, queryField) => ({
-                    ...queries,
-                    [queryField]: {
-                      query: text,
-                      operator: 'or',
-                      fuzziness: 'AUTO',
-                      boost,
-                    },
-                  }),
-                  {}
-                ),
-              },
-            })
-          ),
-          ...Object.entries(searchFieldsBoostMapping).map(
-            ([boost, searchFields]) => ({
-              match_phrase: {
-                ...searchFields(language, index).reduce<{
-                  [key in TranslatableField]?: QueryFilterClauses;
-                }>(
-                  (queries, queryField) => ({
-                    ...queries,
-                    [queryField]: {
-                      query: text,
-                      boost: parseInt(boost) * 2,
-                    },
-                  }),
-                  {}
-                ),
-              },
-            })
-          ),
+          ...searchWithBoolPrefix({ index, language, text }),
+          ...searchWithPhrase({ index, language, text }),
+          searchWithOntology({ index, language, text }),
         ],
       }),
       {}

--- a/graphql/src/datasources/es/api/getQueryResults/utils/getOntologyFields.ts
+++ b/graphql/src/datasources/es/api/getQueryResults/utils/getOntologyFields.ts
@@ -13,9 +13,9 @@ export function getOntologyFields(
       `links.raw_data.ontologyword_ids_enriched.ontologyword_${lang}`,
       `links.raw_data.ontologytree_ids_enriched.name_${lang}`,
       `links.raw_data.ontologytree_ids_enriched.extra_searchwords_${lang}`,
-    ];
+    ] as const;
   } else if (index === ES_EVENT_INDEX) {
-    return [`ontology.${lang}`, 'ontology.alt'];
+    return [`ontology.${lang}`, 'ontology.alt'] as const;
   }
   return [];
 }

--- a/graphql/src/datasources/es/api/getQueryResults/utils/getOntologyQuery.ts
+++ b/graphql/src/datasources/es/api/getQueryResults/utils/getOntologyQuery.ts
@@ -1,7 +1,33 @@
 import { GraphQlToElasticLanguageMap } from '../../../../../constants';
+import { type ElasticLanguage } from '../../../../../types';
 import { ES_DEFAULT_INDEX } from '../../../constants';
 import type { GetQueryResultsProps } from '../types';
 import { getOntologyFields } from './getOntologyFields';
+
+export const getOntologyMatchers = ({
+  index = ES_DEFAULT_INDEX,
+  languages = Object.values(GraphQlToElasticLanguageMap),
+  query,
+}: Pick<GetQueryResultsProps, 'index' | 'languages'> & { query: string }) =>
+  languages.reduce<{
+    [key in ElasticLanguage]?: {
+      multi_match: {
+        query: string;
+        fields: ReturnType<typeof getOntologyFields>;
+      };
+    };
+  }>(
+    (acc, language) => ({
+      ...acc,
+      [language]: {
+        multi_match: {
+          query,
+          fields: getOntologyFields(language, index),
+        },
+      },
+    }),
+    {}
+  );
 
 /** @deprecated Deprecated as unused. */
 export function getOntologyQuery({
@@ -9,18 +35,11 @@ export function getOntologyQuery({
   languages = Object.values(GraphQlToElasticLanguageMap),
   ontology,
 }: Pick<GetQueryResultsProps, 'index' | 'languages' | 'ontology'>) {
-  const ontologyMatchers = languages.reduce(
-    (acc, language) => ({
-      ...acc,
-      [language]: {
-        multi_match: {
-          query: ontology,
-          fields: getOntologyFields(language, index),
-        },
-      },
-    }),
-    {}
-  );
+  const ontologyMatchers = getOntologyMatchers({
+    index,
+    languages,
+    query: ontology,
+  });
 
   return {
     query: {


### PR DESCRIPTION
US-124.
Search also from the ontologies when using
the default text search query for locations.
