### PR TITLE
feat(graphql): add Sentry environment argument to configuration

### DIFF
--- a/graphql/src/index.ts
+++ b/graphql/src/index.ts
@@ -476,4 +476,7 @@ void (async () => {
   });
 })();
 
-Sentry.init({ dsn: process.env.SENTRY_DSN });
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  environment: process.env.SENTRY_ENVIRONMENT,
+});


### PR DESCRIPTION
US-119 US-132. Added the missing environment agument in Sentry init configuration
