### PR TITLE
US-156 | Remove Django admin login page as unneeded

### DIFF
--- a/sources/sources/urls.py
+++ b/sources/sources/urls.py
@@ -1,7 +1,7 @@
 """sources URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/3.1/topics/http/urls/
+    https://docs.djangoproject.com/en/5.2/topics/http/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views
@@ -14,9 +14,5 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
-from django.contrib import admin
-from django.urls import path
-
-urlpatterns = [
-    path("admin/", admin.site.urls),
-]
+# No URL patterns, not even Django admin, as there's no need for it.
+urlpatterns = []


### PR DESCRIPTION
## Description

Remove Django admin login page as unneeded

There's no need for the Django admin login, so removing it to simplify the project.

## Related

[US-156](https://helsinkisolutionoffice.atlassian.net/browse/US-156)