### PR TITLE
US-174 | Fix `/sources/` related deprecations

### DIFF
--- a/sources/ingest/importers/location/utils.py
+++ b/sources/ingest/importers/location/utils.py
@@ -3,8 +3,6 @@ import functools
 from collections import defaultdict
 from typing import Dict, List, Optional, Set
 
-from typing_extensions import deprecated
-
 from ingest.importers.location.api import LocationImporterAPI
 from ingest.importers.location.dataclasses import (
     AccessibilitySentence,
@@ -255,12 +253,6 @@ def create_accessibility_sentence(
     )
 
 
-@deprecated(
-    "Collect accessibility sentences from LocationImporterAPI.fetch_tpr_units instead."
-    "The accessibility sentences are included in the unit query, e.g. "
-    "https://www.hel.fi/palvelukarttaws/rest/v4/unit/42284?official=yes&format=json&newfeatures=yes "  # noqa: E501
-    "which makes this request unnecessary.",
-)
 def get_unit_id_to_accessibility_sentences_mapping(
     use_fallback_languages: bool,
 ) -> Dict[str, List[AccessibilitySentence]]:


### PR DESCRIPTION
## Description

Remove incorrect deprecation of `get_unit_id_to_accessibility_sentences_mapping` function from `/sources/`.

Previously get_unit_id_to_accessibility_sentences_mapping was deprecated based on the idea that accessibility sentences for a unit can be fetched using LocationImporterAPI.fetch_tpr_units function.

Looking at that function it fetches data from
https://www.hel.fi/palvelukarttaws/rest/v4/unit/?newfeatures=yes which DOES NOT include accessibility sentences.

The deprecation text referred to a single unit's fetching e.g. https://www.hel.fi/palvelukarttaws/rest/v4/unit/42284?official=yes&format=json&newfeatures=yes which DOES include accessibility sentences for that unit but it is not the URL that is being used by LocationImporterAPI.fetch_tpr_units. Thus, the deprecation was based on incorrect information.

Removed the deprecation as it was based on incorrect information.

## Related

[US-174](https://helsinkisolutionoffice.atlassian.net/browse/US-174)

## Result

No warnings at all when running `pytest . -vv` anymore.

[US-174]: https://helsinkisolutionoffice.atlassian.net/browse/US-174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ