### PR TITLE
US-120 | EXPOSE port 4000 in graphql's Dockerfile

### DIFF
--- a/graphql/Dockerfile
+++ b/graphql/Dockerfile
@@ -72,7 +72,7 @@ COPY --from=transpiler --chown=root:root /app/dist /app/dist
 ENV NODE_ENV=production
 RUN yarn && yarn cache clean --force
 
-EXPOSE 3000/tcp
+EXPOSE 4000/tcp
 
 # Bake package.json serve command into the image
 USER default


### PR DESCRIPTION
## Description

EXPOSE port 4000 in graphql's Dockerfile

## Related

[US-120](https://helsinkisolutionoffice.atlassian.net/browse/US-120)


[US-120]: https://helsinkisolutionoffice.atlassian.net/browse/US-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ