### PR TITLE
US-151 | Add `commitHash` to readiness endpoint's output

### DIFF
--- a/sources/sources/settings.py
+++ b/sources/sources/settings.py
@@ -173,4 +173,5 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Release/build information:
 APP_RELEASE = os.getenv("APP_RELEASE")
+APP_COMMIT_HASH = os.getenv("APP_COMMIT_HASH")
 APP_BUILD_TIME = datetime.fromtimestamp(os.path.getmtime(__file__))

--- a/sources/sources/urls.py
+++ b/sources/sources/urls.py
@@ -29,6 +29,7 @@ def readiness(*args, **kwargs):
         "status": "ok",
         "release": settings.APP_RELEASE,
         "packageVersion": __version__,
+        "commitHash": settings.APP_COMMIT_HASH or "n/a",
         "buildTime": settings.APP_BUILD_TIME.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
     }
     return JsonResponse(response_json, status=200)


### PR DESCRIPTION
## Description

Add `commitHash` to readiness endpoint's output.

Commit hash was available on dev.azure.com OpenShift environment
using `$(Build.SourceVersion)` so took that into use through
environment variable APP_COMMIT_HASH.

## Related

[US-151](https://helsinkisolutionoffice.atlassian.net/browse/US-151)