### PR TITLE
US-151 | Use better workaround for graphql app's build time

### DIFF
--- a/graphql/src/readiness.ts
+++ b/graphql/src/readiness.ts
@@ -1,15 +1,20 @@
+import { statSync } from 'fs';
+import { fileURLToPath } from 'url';
+
 import type { Response } from 'express';
 
 import packageJson from '../package.json' with { type: 'json' };
 
-// Use this file's evaluation time as a fallback value for build time
-const THIS_FILE_EVALUATION_TIME = new Date().toISOString();
+// Use this file's modification time as a workaround for app build time
+const THIS_FILE_MODIFICATION_TIME = new Date(
+  statSync(fileURLToPath(import.meta.url)).mtime
+).toISOString();
 
 export default function readiness(response: Response) {
   const release = process.env.APP_RELEASE ?? '';
   const packageVersion = packageJson.version;
   const commitHash = process.env.APP_COMMIT_HASH ?? '';
-  const buildTime = process.env.APP_BUILD_TIME ?? THIS_FILE_EVALUATION_TIME;
+  const buildTime = process.env.APP_BUILD_TIME ?? THIS_FILE_MODIFICATION_TIME;
 
   response.status(200).json({
     status: 'ok',


### PR DESCRIPTION
## Description

Use better workaround for graphql app's build time.

Similarly as in sources app's settings.py a file's modification time
is used as a workaround for approximating readiness endpoint's
build time. This is not foolproof, but better than nothing—the previous
way of using the file's evaluation time was probably more problematic
than this as it probably would've changed if the pod got respawned.

## Related

[US-151](https://helsinkisolutionoffice.atlassian.net/browse/US-151)

[US-151]: https://helsinkisolutionoffice.atlassian.net/browse/US-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ