### PR TITLE
US-177 | Remove upgrade-insecure-requests CSP directive from sources app as unneeded

### DIFF
--- a/sources/sources/csp_settings.py
+++ b/sources/sources/csp_settings.py
@@ -23,6 +23,5 @@ CONTENT_SECURITY_POLICY = {
         "form-action": [NONE],
         "manifest-src": [NONE],
         "worker-src": [NONE],
-        "upgrade-insecure-requests": True,
     }
 }

--- a/sources/tests/test_csp.py
+++ b/sources/tests/test_csp.py
@@ -39,7 +39,6 @@ def test_csp_header_content(client):
     sorted_csp_parts = sorted(dir.strip() for dir in csp_header.split(";"))
     expected_sorted_csp_parts = sorted(
         [f"{directive} 'none'" for directive in expected_none_directives]
-        + ["upgrade-insecure-requests"]
     )
     # Compare sorted CSP directives because their order can vary
     assert sorted_csp_parts == expected_sorted_csp_parts


### PR DESCRIPTION
## Description

Remove upgrade-insecure-requests CSP directive from sources app as unneeded.

## Related

[US-177](https://helsinkisolutionoffice.atlassian.net/browse/US-177)

[US-177]: https://helsinkisolutionoffice.atlassian.net/browse/US-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ