### PR TITLE
US-178 | Add permissive CORS to sources app

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.5  # <-- Should match sources/requirements-dev.txt's ruff version!
+    rev: v0.12.7  # <-- Should match sources/requirements-dev.txt's ruff version!
     hooks:
       # Run the linter only for sources directory
       - id: ruff-check

--- a/sources/requirements-dev.txt
+++ b/sources/requirements-dev.txt
@@ -59,7 +59,7 @@ pytest-django==4.11.1
     # via -r requirements-dev.in
 pytest-mock==3.14.1
     # via -r requirements-dev.in
-ruff==0.12.5
+ruff==0.12.7
     # via -r requirements-dev.in
 snapshottest==1.0.0a1
     # via -r requirements-dev.in

--- a/sources/requirements.in
+++ b/sources/requirements.in
@@ -1,5 +1,6 @@
 certifi
 Django
+django-cors-headers
 django-csp
 django-health-check
 django-munigeo

--- a/sources/requirements.txt
+++ b/sources/requirements.txt
@@ -5,7 +5,9 @@
 #    pip-compile requirements.in
 #
 asgiref==3.9.1
-    # via django
+    # via
+    #   django
+    #   django-cors-headers
 attrs==25.3.0
     # via
     #   cattrs
@@ -23,6 +25,7 @@ charset-normalizer==3.4.2
 django==5.2.4
     # via
     #   -r requirements.in
+    #   django-cors-headers
     #   django-csp
     #   django-health-check
     #   django-js-asset
@@ -30,6 +33,8 @@ django==5.2.4
     #   django-parler
     #   django-parler-rest
     #   djangorestframework
+django-cors-headers==4.7.0
+    # via -r requirements.in
 django-csp==4.0
     # via -r requirements.in
 django-health-check==3.20.0
@@ -74,7 +79,7 @@ requests==2.32.4
     #   requests-cache
 requests-cache==1.2.1
     # via django-munigeo
-sentry-sdk==2.33.2
+sentry-sdk==2.34.1
     # via -r requirements.in
 six==1.17.0
     # via

--- a/sources/sources/settings.py
+++ b/sources/sources/settings.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "corsheaders",
     "csp",
     "health_check",
     "custom_health_checks",
@@ -62,6 +63,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "csp.middleware.CSPMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -179,3 +181,13 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 APP_RELEASE = os.getenv("APP_RELEASE")
 APP_COMMIT_HASH = os.getenv("APP_COMMIT_HASH")
 APP_BUILD_TIME = datetime.fromtimestamp(os.path.getmtime(__file__))
+
+# django-cors-headers settings:
+# https://github.com/adamchainz/django-cors-headers/tree/4.7.0?tab=readme-ov-file#configuration
+#
+# This is a very permissive CORS configuration,
+# which is suitable because only readiness/healthz endpoints are available,
+# see sources/sources/urls.py for available endpoints.
+CORS_ALLOW_ALL_ORIGINS = True  # Allow all origins for readiness/healthz endpoints
+CORS_ALLOW_CREDENTIALS = False  # Forbid cookies in cross-site requests
+CORS_ALLOW_METHODS = ["GET", "HEAD"]  # Only for readiness/healthz endpoints

--- a/sources/tests/test_cors.py
+++ b/sources/tests/test_cors.py
@@ -1,0 +1,71 @@
+import pytest
+from django.conf import settings
+
+
+def test_cors_get_method_headers(client):
+    """
+    Test that the CORS headers are set correctly for GET requests.
+    """
+    response = client.get("/readiness", HTTP_ORIGIN="https://example.com")
+    headers = response.headers
+
+    assert headers.get("Access-Control-Allow-Origin") == "*"
+    assert "Access-Control-Allow-Credentials" not in headers
+    assert headers.get("Vary") == "origin"
+    assert "Access-Control-Allow-Methods" not in headers
+
+
+def test_cors_options_method_headers(client):
+    """
+    Test that the CORS headers are set correctly for OPTIONS requests.
+    """
+    response = client.options("/readiness", HTTP_ORIGIN="https://example.com")
+    headers = response.headers
+
+    assert headers.get("Access-Control-Allow-Origin") == "*"
+    assert "Access-Control-Allow-Credentials" not in headers
+    assert headers.get("Vary") == "origin"
+    allowed_methods = sorted(
+        method.strip() for method in headers["Access-Control-Allow-Methods"].split(",")
+    )
+    assert allowed_methods == ["GET", "HEAD"]
+
+
+@pytest.mark.parametrize(
+    "setting_name",
+    [
+        "CORS_ALLOW_HEADERS",
+        "CORS_ALLOW_PRIVATE_NETWORK",
+        "CORS_ALLOWED_ORIGIN_REGEXES",
+        "CORS_ALLOWED_ORIGINS",
+        "CORS_EXPOSE_HEADERS",
+        "CORS_PREFLIGHT_MAX_AGE",
+        "CORS_URLS_REGEX",
+    ],
+)
+def test_unused_cors_settings(setting_name):
+    """
+    Test that unused CORS settings are not set in the Django settings.
+
+    @see https://github.com/adamchainz/django-cors-headers/tree/4.7.0?tab=readme-ov-file#configuration
+    """
+    setting_value = getattr(settings, setting_name, None)
+    assert setting_value is None
+
+
+@pytest.mark.parametrize(
+    "setting_name, expected_setting_value",
+    [
+        ("CORS_ALLOW_ALL_ORIGINS", True),
+        ("CORS_ALLOW_CREDENTIALS", False),
+        ("CORS_ALLOW_METHODS", ["GET", "HEAD"]),
+    ],
+)
+def test_used_cors_settings(setting_name, expected_setting_value):
+    """
+    Test that used CORS settings are as set as expected in the Django settings.
+
+    @see https://github.com/adamchainz/django-cors-headers/tree/4.7.0?tab=readme-ov-file#configuration
+    """
+    setting_value = getattr(settings, setting_name, None)
+    assert setting_value == expected_setting_value

--- a/sources/tests/test_url_patterns.py
+++ b/sources/tests/test_url_patterns.py
@@ -1,0 +1,21 @@
+from collections import namedtuple
+
+from django.urls import get_resolver
+
+NamePattern = namedtuple("NamePattern", ["name", "pattern"])
+
+
+def test_url_patterns():
+    """
+    Ensure that the available URL patterns are as expected.
+    """
+    url_patterns = sorted(
+        NamePattern(x.name, str(x.pattern)) for x in get_resolver().url_patterns
+    )
+    # NOTE: If you add new URL patterns, recheck CORS and CSP settings
+    #       that they are still appropriate.
+    expected_url_patterns = [
+        NamePattern("healthz", "healthz"),
+        NamePattern("readiness", "readiness"),
+    ]
+    assert url_patterns == expected_url_patterns


### PR DESCRIPTION
## Description

Add permissive CORS to sources app.

Configure a permissive CORS for sources app as it only exposes
readiness/healthz endpoints at the moment, and it uses no
authentication and no authorization.
```python
CORS_ALLOW_ALL_ORIGINS = True
CORS_ALLOW_CREDENTIALS = False
CORS_ALLOW_METHODS = ["GET", "HEAD"]
```

Also:
 - Add test that the exposed endpoints are exactly readiness & healthz.

## Related

[US-178](https://helsinkisolutionoffice.atlassian.net/browse/US-178)