### PR TITLE
US-181 | Add Apollo Sandbox support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ ES_URI=http://opensearch-node1:9200
 DEBUG=1
 ALLOWED_HOSTS=*
 CACHE_MAX_AGE=3600
+# Only for non-production use!
+ENABLE_APOLLO_SANDBOX=1

--- a/graphql/src/schemas/location.ts
+++ b/graphql/src/schemas/location.ts
@@ -30,7 +30,7 @@ export const locationSchema = gql`
     city: LanguageString
   }
   """
-  Free-form location, not necessarily at a know venue.
+  Free-form location, not necessarily at a known venue.
   """
   type LocationDescription {
     url: LanguageString
@@ -38,7 +38,6 @@ export const locationSchema = gql`
     address: Address
     explanation: String
     administrativeDivisions: [AdministrativeDivision]
-    venue: UnifiedSearchVenue
   }
   enum TargetGroup {
     ASSOCIATIONS

--- a/graphql/src/schemas/query.ts
+++ b/graphql/src/schemas/query.ts
@@ -195,10 +195,25 @@ export const querySchema = gql`
       size: Int = 5
     ): SearchSuggestionConnection
 
+    """
+    Get Helsinki/Finland administrative divisions i.e.
+    neighborhoods (=kaupunginosat), sub-districts (=osa-alueet),
+    municipalities (=kunnat) etc.
+
+    Based on imported data from [django-munigeo](https://github.com/City-of-Helsinki/django-munigeo):
+    - "geo_import finland --municipalities"
+    - "geo_import helsinki --divisions"
+
+    Used django-munigeo importers:
+    - [geo_import](https://github.com/City-of-Helsinki/django-munigeo/blob/release-0.3.12/munigeo/management/commands/geo_import.py)
+      - [finland](https://github.com/City-of-Helsinki/django-munigeo/blob/release-0.3.12/munigeo/importer/finland.py)
+      - [helsinki](https://github.com/City-of-Helsinki/django-munigeo/blob/release-0.3.12/munigeo/importer/helsinki.py)
+    """
     administrativeDivisions(
       """
-      Return only Helsinki administrative divisions that make a sensible set to be
-      used as an option list in an UI for example.
+      If true, return only Helsinki municipality's neighborhoods and sub-districts
+      (=Helsingin kunnan kaupunginosat ja osa-alueet),
+      otherwise return also all the municipalities of Finland.
       """
       helsinkiCommonOnly: Boolean
     ): [AdministrativeDivision]

--- a/sources/openapi.yaml
+++ b/sources/openapi.yaml
@@ -8,7 +8,7 @@ info:
   version: 2025-08-01-v1
   license:
     name: MIT
-    url: https://opensource.org/license/MIT
+    url: https://github.com/City-of-Helsinki/unified-search/blob/main/LICENSE
 
 servers:
   - url: https://kuva-unified-search-sources.api.test.hel.ninja


### PR DESCRIPTION
## Description

Add Apollo Sandbox support,
can be enabled with `ENABLE_APOLLO_SANDBOX=1` in
`.env` at least when run with Docker Compose locally.

## Related

- [US-181](https://helsinkisolutionoffice.atlassian.net/browse/US-181)
- [Related DevOps pipeline changes](https://dev.azure.com/City-of-Helsinki/kuva-unified-search/_git/kuva-unified-search-pipelines/pullrequest/12028)

[US-181]: https://helsinkisolutionoffice.atlassian.net/browse/US-181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ