### PR TITLE
US-185 | Remove support for `ingest_data` data deletion as unneeded

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,23 +130,15 @@ GraphQL tests under `graphql` folder (Install dependencies with `yarn` first):
 ### Running data importers
 
 For more info, see [Data Importers README](./sources/ingest/README.md),
-but here are some examples of importing data into unified search.
+but here are a few examples of importing data into unified search.
 
-Import all data:
+Import administrative division data:
 
-    docker compose exec sources python manage.py ingest_data
+    docker compose exec sources python manage.py ingest_data administrative_division
 
-Import location data only:
+Import location data:
 
     docker compose exec sources python manage.py ingest_data location
-
-Delete all imported data:
-
-    docker compose exec sources python manage.py ingest_data --delete
-
-Delete imported location data only:
-
-    docker compose exec sources python manage.py ingest_data location --delete
 
 ### Setting up pre-commit hooks
 

--- a/sources/ingest/importers/base.py
+++ b/sources/ingest/importers/base.py
@@ -97,19 +97,6 @@ class Importer(ABC, Generic[IndexableData]):
         logger.debug(f"Applying custom mapping to index {index_name}")
         self.es.indices.put_mapping(index=index_name, body=mapping)
 
-    def delete_all_data(self) -> None:
-        for alias in self.index_base_names:
-            for index_name in (f"{alias}_1", f"{alias}_2"):
-                logger.debug(f"Deleting index {index_name}")
-                try:
-                    response = self.es.indices.delete(index=index_name, ignore=404)
-                    logger.debug(response)
-                except NotFoundError as e:
-                    if e.error == "index_not_found_exception":
-                        logger.debug(f"Index {index_name} does not exist")
-                    else:
-                        raise e
-
     def _initialize(self) -> None:
         for active_alias in self.index_base_names:
             logger.debug(f"Initializing {active_alias}")

--- a/sources/ingest/management/commands/ingest_data.py
+++ b/sources/ingest/management/commands/ingest_data.py
@@ -35,11 +35,6 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         # Named (optional) arguments
         parser.add_argument(
-            "--delete",
-            action="store_true",
-            help="Delete stored data",
-        )
-        parser.add_argument(
             "--ignore-fallback-languages",  # Turn off use_fallback_languages
             dest="use_fallback_languages",
             action="store_false",  # Means use_fallback_languages=False because of dest
@@ -63,10 +58,6 @@ class Command(BaseCommand):
 
         importer_map = self.get_importer_map(kwargs["importer"])
 
-        if kwargs["delete"]:
-            self.handle_delete(importer_map)
-            return
-
         self.handle_import(
             importer_map,
             use_fallback_languages=kwargs.get("use_fallback_languages", True),
@@ -88,15 +79,6 @@ class Command(BaseCommand):
                     f"allowed: {list(self.all_importers.keys())}."
                 )
         return importer_map
-
-    def handle_delete(self, importer_map: ImporterMap) -> None:
-        for importer_name, importer_class in importer_map.items():
-            logger.info(f"Deleting data {importer_name}")
-            try:
-                importer_class().delete_all_data()
-            except Exception as e:  # noqa
-                logger.exception(e)
-                raise e
 
     def handle_import(
         self, importer_map: ImporterMap, use_fallback_languages: bool


### PR DESCRIPTION
## Description

The support for deleting data using `ingest_data` management
command was broken (specifically location importer didn't just
delete data when asked to but it ALSO imported data even when
it shouldn't have), and is not used in Azure DevOps, so it can be
safely removed.

This is simplifying the codebase by removing broken functionality
that "might be useful" in a sense, but probably isn't *really* needed.

## Related

[US-185](https://helsinkisolutionoffice.atlassian.net/browse/US-185)

[US-185]: https://helsinkisolutionoffice.atlassian.net/browse/US-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ