### PR TITLE
US-183 | Enable typechecking of graphql project in github actions

### DIFF
--- a/.github/workflows/ci-graphql.yml
+++ b/.github/workflows/ci-graphql.yml
@@ -14,3 +14,4 @@ jobs:
     with:
       node-version: 22
       working-directory: ./graphql
+      typecheck: true


### PR DESCRIPTION
## Description

Enable typechecking of graphql project in github actions.

## Related

[US-183](https://helsinkisolutionoffice.atlassian.net/browse/US-183)

[US-183]: https://helsinkisolutionoffice.atlassian.net/browse/US-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ