### PR TITLE
US-183 | Update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ You can use [`pre-commit`](https://pre-commit.com/) to lint and format your code
 2. Set up git hooks from `.pre-commit-config.yaml` by running these commands from project root:
    - `pre-commit install` to enable pre-commit code formatting & linting
    - `pre-commit install --hook-type commit-msg` to enable pre-commit commit message linting
+3. To be able to successfully run the pre-commit hooks for the `graphql` app, you need to install its dependencies:
+   - `yarn --cwd graphql` (Installs dependencies in the `graphql` folder)
 
 After that, linting and formatting hooks will run against all changed files before committing.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,14 @@ Unified search consists of the following applications:
 ### Elasticsearch
 
 - Search engine for indexing the data
-- All environments use [Elasticsearch](https://www.elastic.co/elasticsearch), except local development, which uses [OpenSearch](https://opensearch.org/) 
+- All environments use [Elasticsearch](https://www.elastic.co/elasticsearch) except:
+  - Local development and all tests run in any environment use [OpenSearch](https://opensearch.org/)
+
+Why OpenSearch is used at all?
+- OpenSearch was chosen earlier for local development only because of Elasticsearch's licensing.
+  As Elasticsearch has changed their licensing later, it could be possible to switch to it in all environments.
+  If this is possible, it would also be preferrable because of unification of the used search engine i.e.
+  testing and using the same engine in all environments.
 
 ### Data collector
 

--- a/graphql/Dockerfile
+++ b/graphql/Dockerfile
@@ -55,18 +55,17 @@ USER default
 CMD ["yarn", "start"]
 
 # =============================
-FROM development_base AS transpiler
+FROM development_base AS builder
 # =============================
 
-# Transpile Typescript into Javascript
-RUN yarn transpile
+RUN yarn build
 
 # =============================
 FROM appbase AS production
 # =============================
 
-# Copy the transpiled source files to this image
-COPY --from=transpiler --chown=root:root /app/dist /app/dist
+# Copy the built source files to this image
+COPY --from=builder --chown=root:root /app/dist /app/dist
 
 # Set node environment to production to install only main dependencies
 ENV NODE_ENV=production

--- a/graphql/README.md
+++ b/graphql/README.md
@@ -13,7 +13,8 @@ for end users of [Unified Search](https://github.com/City-of-Helsinki/unified-se
   - [With Docker & Docker compose](#with-docker--docker-compose)
   - [Without Docker](#without-docker)
 - [Environments](#environments)
-- [GraphQL queries](#graphql-queries)
+- [Weighting of search results](#weighting-of-search-results)
+- [Example GraphQL queries](#example-graphql-queries)
   - [Administrative divisions query](#administrative-divisions-query)
   - [Free text search - location index](#free-text-search---location-index)
   - [Pagination and scores](#pagination-and-scores)
@@ -61,9 +62,38 @@ Based on info from [kuva-unified-search](https://dev.azure.com/City-of-Helsinki/
 - Staging: https://kuva-unified-search.api.stage.hel.ninja/search
 - Production: https://kuva-unified-search.api.hel.fi/search
 
-## GraphQL queries
+## Weighting of search results
+
+To give more importance to certain fields in search results,
+GraphQL search API's search results are weighted.
+
+Here are the location/venue search's used weights:
+
+| Field       | Single word match | Phrase match (2x single match) |
+| ----------- | ----------------- | ------------------------------ |
+| name        | 3x                | 6x                             |
+| description | 1x                | 2x                             |
+
+So this makes it so that phrase matches (e.g. "art museum") in `name` field
+are weighted highest (6x), followed by single word matches (e.g. "art" or "museum")
+in `name` (3x), followed by phrase matches in `description` (2x), and finally the
+single word matches in `description` (1x).
+
+Given the above, location/venue search prioritizes the search matches in this order:
+
+1. `name` field phrase match
+2. `name` field single word match
+3. `description` field phrase match
+4. `description` field single word match
+
+The weights are defined in [constants files](./src/datasources/es/api/getQueryResults/constants.ts).
+
+## Example GraphQL queries
 
 It is recommended to use a GraphQL client for sending queries.
+
+You can also use the Apollo Sandbox GraphQL client, if you have it enabled with
+`ENABLE_APOLLO_SANDBOX=true` in your `.env` file, locally at http://localhost:4000/search
 
 ### Administrative divisions query
 

--- a/graphql/README.md
+++ b/graphql/README.md
@@ -47,7 +47,7 @@ its use is described in the [repository root README](../README.md).
 1. Install [requirements](#requirements)
    - Node.js using e.g. [nvm](https://github.com/nvm-sh/nvm) / [nvm-windows](https://github.com/coreybutler/nvm-windows)
    - Yarn v1 using e.g. [Yarn installation guide](https://classic.yarnpkg.com/lang/en/docs/install/)
-2. Run `yarn start` for development, or `yarn transpile` & `yarn serve` for production build.
+2. Run `yarn start` for development, or `yarn build` & `yarn serve` for production build.
 
 ## Environments
 

--- a/graphql/README.md
+++ b/graphql/README.md
@@ -56,6 +56,7 @@ Where is the GraphQL API running?
 Based on info from [kuva-unified-search](https://dev.azure.com/City-of-Helsinki/kuva-unified-search) Azure DevOps project:
 
 - Review per PR (e.g. PR #321): https://kuva-unified-search-pr321.api.dev.hel.ninja/search
+- Development: https://kuva-unified-search.api.dev.hel.ninja/search
 - Testing: https://kuva-unified-search.api.test.hel.ninja/search
 - Staging: https://kuva-unified-search.api.stage.hel.ninja/search
 - Production: https://kuva-unified-search.api.hel.fi/search

--- a/graphql/package.json
+++ b/graphql/package.json
@@ -10,7 +10,6 @@
   "scripts": {
     "build": "tsc",
     "start": "nodemon --ext ts src/index.ts --exec tsx",
-    "transpile": "tsc",
     "typecheck": "tsc --project ./tsconfig.json --noEmit",
     "serve": "node --import ./dist/src/sentry-init.mjs --trace-warnings --max-http-header-size=16000 dist/src/index.js",
     "test": "vitest",

--- a/graphql/src/datasources/es/api/getQueryResults/constants.ts
+++ b/graphql/src/datasources/es/api/getQueryResults/constants.ts
@@ -28,6 +28,9 @@ export const SEARCH_WEIGHT = {
   veryHigh: 3,
 } as const;
 
+export type SearchWeight = (typeof SEARCH_WEIGHT)[keyof typeof SEARCH_WEIGHT];
+export type StringSearchWeight = `${SearchWeight}`;
+
 /**
  * Boost multiplier for `match_phrase` queries.
  *
@@ -43,15 +46,17 @@ export const SEARCH_WEIGHT = {
 export const MATCH_PHRASE_BOOST_MULTIPLIER = SEARCH_WEIGHT.high;
 
 // Some fields should be boosted / weighted to get more relevant result set
-export const searchFieldsBoostMapping: Record<
-  string,
-  (lang: ElasticLanguage, index: ElasticSearchIndex) => TranslatableField[]
+export const searchFieldsBoostMapping: Partial<
+  Record<
+    StringSearchWeight, // Javascript converts numbers to strings, so let's use strings
+    (lang: ElasticLanguage, index: ElasticSearchIndex) => TranslatableField[]
+  >
 > = {
   // Normally weighted search fields for different indexes
   [SEARCH_WEIGHT.normal]: (
     lang: ElasticLanguage,
     index: ElasticSearchIndex
-  ) => {
+  ): TranslatableField[] => {
     return (
       {
         [ES_LOCATION_INDEX]: [`venue.description.${lang}`],
@@ -61,7 +66,7 @@ export const searchFieldsBoostMapping: Record<
   [SEARCH_WEIGHT.veryHigh]: (
     lang: ElasticLanguage,
     index: ElasticSearchIndex
-  ) => {
+  ): TranslatableField[] => {
     return (
       {
         [ES_LOCATION_INDEX]: [`venue.name.${lang}`],

--- a/sources/README.md
+++ b/sources/README.md
@@ -51,6 +51,7 @@ Where is the Data Collector running?
 Based on info from [kuva-unified-search](https://dev.azure.com/City-of-Helsinki/kuva-unified-search) Azure DevOps project:
 
 - Review per PR (e.g. PR #321): https://kuva-unified-search-sources-pr321.api.dev.hel.ninja/
+- Development: https://kuva-unified-search-sources.api.dev.hel.ninja/
 - Testing: https://kuva-unified-search-sources.api.test.hel.ninja/
 - Staging: https://kuva-unified-search-sources.api.stage.hel.ninja/
 - Production: https://kuva-unified-search-sources.api.hel.ninja/

--- a/sources/openapi.yaml
+++ b/sources/openapi.yaml
@@ -11,6 +11,8 @@ info:
     url: https://github.com/City-of-Helsinki/unified-search/blob/main/LICENSE
 
 servers:
+  - url: https://kuva-unified-search-sources.api.dev.hel.ninja
+    description: Development environment
   - url: https://kuva-unified-search-sources.api.test.hel.ninja
     description: Testing environment
   - url: https://kuva-unified-search-sources.api.stage.hel.ninja


### PR DESCRIPTION
## Description

Update READMEs:
- add information to README about why OpenSearch is used
- document search weighting factors in README
- add development environments to READMEs
- add more info about how to set up pre-commit hooks successfully

Also:
- change vocabulary & scripts from using transpile → build

## Related

[US-183](https://helsinkisolutionoffice.atlassian.net/browse/US-183)

[US-183]: https://helsinkisolutionoffice.atlassian.net/browse/US-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ