### PR TITLE
US-181 | Add endpoint documentation links to READMEs

### DIFF
--- a/graphql/README.md
+++ b/graphql/README.md
@@ -13,6 +13,7 @@ for end users of [Unified Search](https://github.com/City-of-Helsinki/unified-se
   - [With Docker & Docker compose](#with-docker--docker-compose)
   - [Without Docker](#without-docker)
 - [Environments](#environments)
+- [GraphQL search API documentation](#graphql-search-api-documentation)
 - [Weighting of search results](#weighting-of-search-results)
 - [Example GraphQL queries](#example-graphql-queries)
   - [Administrative divisions query](#administrative-divisions-query)
@@ -61,6 +62,13 @@ Based on info from [kuva-unified-search](https://dev.azure.com/City-of-Helsinki/
 - Testing: https://kuva-unified-search.api.test.hel.ninja/search
 - Staging: https://kuva-unified-search.api.stage.hel.ninja/search
 - Production: https://kuva-unified-search.api.hel.fi/search
+
+## GraphQL search API documentation
+
+The GraphQL search API's documentation is available at `/search` endpoint
+(as long as Apollo Sandbox has been enabled with `ENABLE_APOLLO_SANDBOX=true`):
+- Locally: http://localhost:4000/search
+- In deployed environments, see [Environments](#environments)
 
 ## Weighting of search results
 

--- a/sources/README.md
+++ b/sources/README.md
@@ -13,6 +13,7 @@ and storing it to Elasticsearch.
   - [Without Docker](#without-docker)
 - [Environments](#environments)
 - [Data importers](#data-importers)
+- [Endpoints](#endpoints)
 - [Keeping Python requirements up to date](#keeping-python-requirements-up-to-date)
 - [Code linting & formatting](#code-linting--formatting)
 - [Pre-commit hooks](#pre-commit-hooks)
@@ -61,6 +62,11 @@ Based on info from [kuva-unified-search](https://dev.azure.com/City-of-Helsinki/
 Data collector uses multiple different data importers to fetch data.
 
 The data importers are documented in [Data Importers README](./ingest/README.md).
+
+## Endpoints
+
+Data Collector doesn't have many endpoints, just the ones needed for
+readiness and health checks. They are documented in [openapi.yaml](./openapi.yaml).
 
 ## Keeping Python requirements up to date
 


### PR DESCRIPTION
## Description

Add endpoint documentation links to READMEs.

## Related

[US-181](https://helsinkisolutionoffice.atlassian.net/browse/US-181)

[US-181]: https://helsinkisolutionoffice.atlassian.net/browse/US-181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ