### PR TITLE
(→PR #190) US-19 | Upgrade OpenSearch v1.3.1 → v3.2.0

### DIFF
--- a/.github/workflows/ci-sources.yml
+++ b/.github/workflows/ci-sources.yml
@@ -27,7 +27,7 @@ jobs:
           -e "discovery.type=single-node" \
           -e "plugins.security.disabled=true" \
           -e OPENSEARCH_INITIAL_ADMIN_PASSWORD='Very_Strong_Password_123456' \
-          opensearchproject/opensearch:1.3.1
+          opensearchproject/opensearch:3.2.0
         
         echo 'ES_URI=http://localhost:9200' >> .env
         sudo apt-get install gdal-bin libsqlite3-mod-spatialite

--- a/compose.yaml
+++ b/compose.yaml
@@ -39,7 +39,7 @@ services:
       - opensearch-net
 
   opensearch-node1:
-    image: opensearchproject/opensearch:1.3.1
+    image: opensearchproject/opensearch:3.2.0
     container_name: opensearch-node1
     environment:
       - cluster.name=opensearch-cluster
@@ -65,7 +65,7 @@ services:
       - opensearch-net
   
   opensearch-node2:
-    image: opensearchproject/opensearch:1.3.1
+    image: opensearchproject/opensearch:3.2.0
     container_name: opensearch-node2
     environment:
       - cluster.name=opensearch-cluster
@@ -88,7 +88,7 @@ services:
       - opensearch-net
 
   opensearch-node3:
-    image: opensearchproject/opensearch:1.3.1
+    image: opensearchproject/opensearch:3.2.0
     container_name: opensearch-node3
     environment:
       - cluster.name=opensearch-cluster
@@ -111,7 +111,7 @@ services:
       - opensearch-net
 
   opensearch-dashboards:
-    image: opensearchproject/opensearch-dashboards:1.3.1
+    image: opensearchproject/opensearch-dashboards:3.2.0
     container_name: opensearch-dashboards
     ports:
       - 5601:5601

--- a/sources/ingest/importers/tests/snapshots/snap_test_base_importer.py
+++ b/sources/ingest/importers/tests/snapshots/snap_test_base_importer.py
@@ -15,8 +15,7 @@ snapshots['test_importer_end_results 1'] = {
             '_score': 1.0,
             '_source': {
                 'foo': 'import number 1'
-            },
-            '_type': '_doc'
+            }
         }
     ],
     'max_score': 1.0,
@@ -43,8 +42,7 @@ snapshots['test_importer_end_results 3'] = {
             '_score': 1.0,
             '_source': {
                 'foo': 'import number 2'
-            },
-            '_type': '_doc'
+            }
         }
     ],
     'max_score': 1.0,
@@ -71,8 +69,7 @@ snapshots['test_importer_end_results 5'] = {
             '_score': 1.0,
             '_source': {
                 'foo': 'import number 3'
-            },
-            '_type': '_doc'
+            }
         }
     ],
     'max_score': 1.0,
@@ -99,8 +96,7 @@ snapshots['test_importer_wip_results[does not have old data] 1'] = {
             '_score': 1.0,
             '_source': {
                 'foo': 'new data'
-            },
-            '_type': '_doc'
+            }
         }
     ],
     'max_score': 1.0,
@@ -129,8 +125,7 @@ snapshots['test_importer_wip_results[has old data] 1'] = {
             '_score': 1.0,
             '_source': {
                 'foo': 'old data'
-            },
-            '_type': '_doc'
+            }
         }
     ],
     'max_score': 1.0,


### PR DESCRIPTION
## Description

Upgrade OpenSearch v1.3.1 → v3.2.0.

Alternative of switching to Elasticsearch in PR #190 

## Manual testing

Need to remove old volumes related to the Docker compose setup, as there is no
two major versions jump backward compatibility.
This can be done locally with e.g. `docker compose down --remove-orphans -v`.

## Related

[US-194](https://helsinkisolutionoffice.atlassian.net/browse/US-194)

[US-194]: https://helsinkisolutionoffice.atlassian.net/browse/US-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ