### PR TITLE
US-194 | Switch to Elasticsearch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 SECRET_KEY=123123
 # When running everything in Docker compose:
-ES_URI=http://opensearch-node1:9200
+ES_URI=http://elasticsearch-node1:9200
 # When running `sources` in virtual environment:
 # ES_URI=http://localhost:9200
 DEBUG=1

--- a/.github/workflows/ci-sources.yml
+++ b/.github/workflows/ci-sources.yml
@@ -13,23 +13,22 @@ jobs:
     secrets: inherit
     with:
       python-version: 3.12
+      # PostgreSQL is NOT USED in sources app at all, but ci-django-api.yml requires this to be set:
       postgres-major-version: 13
       working-directory: ./sources
       extra-commands: |
-        # Start local OpenSearch for testing. It will be destroyed after the tests are done.
-        # You can only log in to the Opensearch container from a runnable environment. 
+        # Start local Elasticsearch for testing. It will be destroyed after the tests are done.
+        # You can only log in to the Elasticsearch container from a runnable environment.
         # The container is only for tests in this repository and only exists for the duration of the tests. 
-        # For this reason, protecting the Opensearch admin password is not justified.
         docker run -d \
-          --name opensearch \
+          --name elasticsearch \
           -p 9200:9200 \
-          -p 9600:9600 \
           -e "discovery.type=single-node" \
-          -e "plugins.security.disabled=true" \
-          -e OPENSEARCH_INITIAL_ADMIN_PASSWORD='Very_Strong_Password_123456' \
-          opensearchproject/opensearch:1.3.1
+          -e "action.destructive_requires_name=false" \
+          -e "xpack.security.enabled=false" \
+          docker.elastic.co/elasticsearch/elasticsearch:9.1.3
         
         echo 'ES_URI=http://localhost:9200' >> .env
         sudo apt-get install gdal-bin libsqlite3-mod-spatialite
         
-        docker logs opensearch
+        docker logs elasticsearch

--- a/README.md
+++ b/README.md
@@ -27,14 +27,7 @@ Unified search consists of the following applications:
 ### Elasticsearch
 
 - Search engine for indexing the data
-- All environments use [Elasticsearch](https://www.elastic.co/elasticsearch) except:
-  - Local development and all tests run in any environment use [OpenSearch](https://opensearch.org/)
-
-Why OpenSearch is used at all?
-- OpenSearch was chosen earlier for local development only because of Elasticsearch's licensing.
-  As Elasticsearch has changed their licensing later, it could be possible to switch to it in all environments.
-  If this is possible, it would also be preferrable because of unification of the used search engine i.e.
-  testing and using the same engine in all environments.
+- All environments use [Elasticsearch](https://www.elastic.co/elasticsearch)
 
 ### Data collector
 
@@ -107,9 +100,9 @@ Services can now be locally accessed at:
 | Service                                   | Local URL                                    |
 |-------------------------------------------|----------------------------------------------|
 | [GraphQL search API](./graphql/README.md) | http://localhost:4000/search                 |
-| OpenSearch Dashboards                     | http://localhost:5601                        |
-| OpenSearch Dashboards Dev Tools           | http://localhost:5601/app/dev_tools#/console |
-| OpenSearch                                | http://localhost:9200                        |
+| Elastic Stack home                        | http://localhost:5601                        |
+| Elasticsearch Dev Tools                   | http://localhost:5601/app/dev_tools#/console |
+| Elasticsearch                             | http://localhost:9200                        |
 | [Data collector](./sources/README.md)     | http://localhost:5001/readiness              |
 
 ### Running without Docker

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,10 +1,12 @@
-x-base: &base
-  env_file:
-    - .env
-
+# Docker Compose file for local development only
+#
+# Disclaimer:
+#   This is NOT SECURE, and should only be used with data that is not sensitive.
+#   Currently unified search only imports open public data, but if this ever
+#   changes, the setup should be made more secure!
 services:
   sources:
-    <<: *base
+    env_file: .env
     build:
       context: ./sources
       target: ${DOCKER_TARGET:-development}  # target Dockerfile stage
@@ -18,11 +20,9 @@ services:
       # Exclude directories to avoid host/container incompatibility & permission issues:
       - /app/db_data
       - /app/.pytest_cache
-    networks:
-      - opensearch-net
 
   search-api:
-    <<: *base
+    env_file: .env
     build:
       context: ./graphql
       target: ${DOCKER_TARGET:-development}  # target Dockerfile stage
@@ -35,102 +35,46 @@ services:
     ports:
       - "4000:4000"
     restart: unless-stopped
-    networks:
-      - opensearch-net
 
-  opensearch-node1:
-    image: opensearchproject/opensearch:1.3.1
-    container_name: opensearch-node1
+  elasticsearch-node1:
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.1.3
+    container_name: elasticsearch-node1
     environment:
-      - cluster.name=opensearch-cluster
-      - node.name=opensearch-node1
-      - discovery.seed_hosts=opensearch-node1,opensearch-node2,opensearch-node3
-      - cluster.initial_master_nodes=opensearch-node1,opensearch-node2,opensearch-node3
+      - cluster.name=elasticsearch-cluster
+      - action.destructive_requires_name=false  # allow wildcard index deletes (e.g. "test_*") for tests
+      - node.name=elasticsearch-node1
+      - discovery.type=single-node
       - bootstrap.memory_lock=false  # disabled because doesn't work on macOS -> thus, swapping is enabled
-      - "DISABLE_SECURITY_PLUGIN=true" # disables security plugin entirely in OpenSearch by setting plugins.security.disabled: true in opensearch.yml
-      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+      - "xpack.security.enabled=false" # disables security entirely in Elasticsearch (only for local development!)
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
     ulimits:
       memlock:
         soft: -1
         hard: -1
       nofile:
-        soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
+        soft: 65536 # maximum number of open files for the Elasticsearch user, set to at least 65536 on modern systems
         hard: 65536
-    volumes:
-      - opensearch-data1:/usr/share/opensearch/data
     ports:
       - 9200:9200
-      - 9600:9600 # required for Performance Analyzer
-    networks:
-      - opensearch-net
-  
-  opensearch-node2:
-    image: opensearchproject/opensearch:1.3.1
-    container_name: opensearch-node2
-    environment:
-      - cluster.name=opensearch-cluster
-      - node.name=opensearch-node2
-      - discovery.seed_hosts=opensearch-node1,opensearch-node2,opensearch-node3
-      - cluster.initial_master_nodes=opensearch-node1,opensearch-node2,opensearch-node3
-      - bootstrap.memory_lock=false  # disabled because doesn't work on macOS -> thus, swapping is enabled
-      - "DISABLE_SECURITY_PLUGIN=true" # disables security plugin entirely in OpenSearch by setting plugins.security.disabled: true in opensearch.yml
-      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-      nofile:
-        soft: 65536
-        hard: 65536
     volumes:
-      - opensearch-data2:/usr/share/opensearch/data
-    networks:
-      - opensearch-net
+      - elasticsearch-data1:/usr/share/elasticsearch/data
 
-  opensearch-node3:
-    image: opensearchproject/opensearch:1.3.1
-    container_name: opensearch-node3
-    environment:
-      - cluster.name=opensearch-cluster
-      - node.name=opensearch-node3
-      - discovery.seed_hosts=opensearch-node1,opensearch-node2,opensearch-node3
-      - cluster.initial_master_nodes=opensearch-node1,opensearch-node2,opensearch-node3
-      - bootstrap.memory_lock=false  # disabled because doesn't work on macOS -> thus, swapping is enabled
-      - "DISABLE_SECURITY_PLUGIN=true" # disables security plugin entirely in OpenSearch by setting plugins.security.disabled: true in opensearch.yml
-      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-      nofile:
-        soft: 65536
-        hard: 65536
-    volumes:
-      - opensearch-data3:/usr/share/opensearch/data
-    networks:
-      - opensearch-net
-
-  opensearch-dashboards:
-    image: opensearchproject/opensearch-dashboards:1.3.1
-    container_name: opensearch-dashboards
+  kibana:
+    depends_on:
+      - elasticsearch-node1
+    image: docker.elastic.co/kibana/kibana:9.1.3
+    container_name: kibana
     ports:
       - 5601:5601
     expose:
       - "5601"
     environment:
-      - 'OPENSEARCH_HOSTS=["http://opensearch-node1:9200","http://opensearch-node2:9200","http://opensearch-node3:9200"]'
-      - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true" # disables security dashboards plugin in OpenSearch Dashboards
-    networks:
-      - opensearch-net
+      - 'ELASTICSEARCH_HOSTS=["http://elasticsearch-node1:9200"]'
 
 volumes:
-  opensearch-data1:
-    driver: local
-  opensearch-data2:
-    driver: local
-  opensearch-data3:
+  elasticsearch-data1:
     driver: local
 
 networks:
-  opensearch-net:
-    driver: bridge
+    default:
+        name: helsinki

--- a/graphql/README.md
+++ b/graphql/README.md
@@ -289,7 +289,7 @@ query {
 
 ## Elasticsearch queries
 
-You can run these queries [locally in OpenSearch Dashboards Dev Tools](http://localhost:5601/app/dev_tools#/console).
+You can run these queries [locally in Elasticsearch Dev Tools](http://localhost:5601/app/dev_tools#/console).
 
 ### Date ranges
 

--- a/graphql/src/datasources/es/constants.ts
+++ b/graphql/src/datasources/es/constants.ts
@@ -21,7 +21,7 @@ export const SEARCH_RESULT_FIELDS = [VENUE_SEARCH_RESULT_FIELD] as const;
 export const ELASTIC_SEARCH_URI: string = process.env.ES_URI;
 export const DEFAULT_TIME_ZONE = 'Europe/Helsinki' as const;
 // The default page size when the first argument is not given.
-// This is the default page size set by OpenSearch / ElasticSearch
+// This is the default page size set by ElasticSearch
 export const ES_DEFAULT_PAGE_SIZE = 10 as const;
 
 /**

--- a/sources/ingest/importers/location/dataclasses.py
+++ b/sources/ingest/importers/location/dataclasses.py
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class ServiceOwner:
-    providerType: str  # ProviderType as string to fix OpenSearch serialization
-    type: str  # ServiceOwnerType as string to fix OpenSearch serialization
+    providerType: str  # ProviderType as str to fix Elasticsearch serialization
+    type: str  # ServiceOwnerType as str to fix Elasticsearch serialization
     name: LanguageString
 
 
@@ -46,9 +46,9 @@ class AccessibilitySentence:
 
 @dataclass(eq=True, order=True)
 class AccessibilityViewpoint:
-    id: str  # AccessibilityViewpointID as string to fix OpenSearch serialization
+    id: str  # AccessibilityViewpointID as str to fix Elasticsearch serialization
     name: LanguageString
-    value: str  # AccessibilityViewpointValue as string to fix OpenSearch serialization
+    value: str  # AccessibilityViewpointValue as str to fix Elasticsearch serialization
     shortages: Optional[List[LanguageString]] = None
 
 
@@ -121,7 +121,7 @@ class AccessibilityShortcoming:
     e.g. hearing_aid has 3 shortcomings
     """
 
-    profile: str  # AccessibilityProfile as string to fix OpenSearch serialization
+    profile: str  # AccessibilityProfile as str to fix Elasticsearch serialization
     count: Optional[int]  # None means unknown
 
 
@@ -272,7 +272,7 @@ class Venue:
     location: Location = None
     description: LanguageString = None
     serviceOwner: Optional[ServiceOwner] = None
-    # List[TargetGroup] as List[str] to fix OpenSearch serialization:
+    # List[TargetGroup] as List[str] to fix Elasticsearch serialization:
     targetGroups: List[str] = field(default_factory=list)
     openingHours: OpeningHours = None
     reservation: Optional[Reservation] = None

--- a/sources/ingest/importers/tests/conftest.py
+++ b/sources/ingest/importers/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 from django.conf import settings
-from opensearchpy import OpenSearch
+from elasticsearch import Elasticsearch
 
 from ingest.importers.tests.mocks import (
     MOCK_OPENING_HOURS_RESPONSE,
@@ -98,7 +98,7 @@ def mocked_service_registry_description_viewpoint_response(mocker):
 
 @pytest.fixture
 def es():
-    es = OpenSearch([settings.ES_URI])
+    es = Elasticsearch([settings.ES_URI])
     yield es
     es.indices.delete(index="test_*")
 

--- a/sources/ingest/importers/tests/snapshots/snap_test_base_importer.py
+++ b/sources/ingest/importers/tests/snapshots/snap_test_base_importer.py
@@ -2,7 +2,7 @@
 # snapshottest: v1 - https://goo.gl/zC4yUc
 from __future__ import unicode_literals
 
-from snapshottest import Snapshot
+from snapshottest import GenericRepr, Snapshot
 
 
 snapshots = Snapshot()
@@ -15,8 +15,7 @@ snapshots['test_importer_end_results 1'] = {
             '_score': 1.0,
             '_source': {
                 'foo': 'import number 1'
-            },
-            '_type': '_doc'
+            }
         }
     ],
     'max_score': 1.0,
@@ -43,8 +42,7 @@ snapshots['test_importer_end_results 3'] = {
             '_score': 1.0,
             '_source': {
                 'foo': 'import number 2'
-            },
-            '_type': '_doc'
+            }
         }
     ],
     'max_score': 1.0,
@@ -71,8 +69,7 @@ snapshots['test_importer_end_results 5'] = {
             '_score': 1.0,
             '_source': {
                 'foo': 'import number 3'
-            },
-            '_type': '_doc'
+            }
         }
     ],
     'max_score': 1.0,
@@ -99,8 +96,7 @@ snapshots['test_importer_wip_results[does not have old data] 1'] = {
             '_score': 1.0,
             '_source': {
                 'foo': 'new data'
-            },
-            '_type': '_doc'
+            }
         }
     ],
     'max_score': 1.0,
@@ -129,8 +125,7 @@ snapshots['test_importer_wip_results[has old data] 1'] = {
             '_score': 1.0,
             '_source': {
                 'foo': 'old data'
-            },
-            '_type': '_doc'
+            }
         }
     ],
     'max_score': 1.0,

--- a/sources/requirements.in
+++ b/sources/requirements.in
@@ -4,7 +4,7 @@ django-cors-headers
 django-csp
 django-health-check
 django-munigeo
-opensearch-py
+elasticsearch
 pyhumps
 python-dotenv
 requests

--- a/sources/requirements.txt
+++ b/sources/requirements.txt
@@ -17,7 +17,7 @@ cattrs==25.2.0
 certifi==2025.8.3
     # via
     #   -r requirements.in
-    #   opensearch-py
+    #   elastic-transport
     #   requests
     #   sentry-sdk
 charset-normalizer==3.4.3
@@ -53,14 +53,14 @@ django-parler-rest==2.2
     # via django-munigeo
 djangorestframework==3.16.1
     # via django-parler-rest
-events==0.5
-    # via opensearch-py
+elastic-transport==9.1.0
+    # via elasticsearch
+elasticsearch==9.1.0
+    # via -r requirements.in
 idna==3.10
     # via
     #   requests
     #   url-normalize
-opensearch-py==3.0.0
-    # via -r requirements.in
 packaging==25.0
     # via django-csp
 platformdirs==4.4.0
@@ -68,7 +68,7 @@ platformdirs==4.4.0
 pyhumps==3.8.0
     # via -r requirements.in
 python-dateutil==2.9.0.post0
-    # via opensearch-py
+    # via elasticsearch
 python-dotenv==1.1.1
     # via -r requirements.in
 pyyaml==6.0.2
@@ -77,7 +77,6 @@ requests==2.32.5
     # via
     #   -r requirements.in
     #   django-munigeo
-    #   opensearch-py
     #   requests-cache
 requests-cache==1.2.1
     # via django-munigeo
@@ -90,12 +89,14 @@ six==1.17.0
 sqlparse==0.5.3
     # via django
 typing-extensions==4.15.0
-    # via cattrs
+    # via
+    #   cattrs
+    #   elasticsearch
 url-normalize==2.2.1
     # via requests-cache
 urllib3==2.5.0
     # via
-    #   opensearch-py
+    #   elastic-transport
     #   requests
     #   requests-cache
     #   sentry-sdk

--- a/sources/tests/test_es_health.py
+++ b/sources/tests/test_es_health.py
@@ -3,7 +3,7 @@ import logging
 
 import requests
 from django.conf import settings
-from opensearchpy import exceptions, OpenSearch
+from elasticsearch import Elasticsearch, exceptions
 
 """ Running:
         pytest
@@ -21,7 +21,7 @@ logging.basicConfig(
 
 
 def test_es_up():
-    logging.debug("Checking OpenSearch connection")
+    logging.debug("Checking Elasticsearch connection")
     r = requests.get(settings.ES_URI)
     logging.debug(json.dumps(json.loads(r.content), indent=4))
     assert r.status_code == 200
@@ -30,7 +30,7 @@ def test_es_up():
 def test_es_basic_operations():
     """Run basic operations for testing purposes."""
 
-    es = OpenSearch([settings.ES_URI])
+    es = Elasticsearch([settings.ES_URI])
 
     try:
         logging.debug("Deleting existing test data")


### PR DESCRIPTION
## Description

Switch from OpenSearch → ElasticSearch & Kibana v9.1.3.

See commit messages for more details.

### Regarding the license of Elasticsearch

https://www.elastic.co/blog/elasticsearch-is-open-source-again (August 2024):
> The tl;dr is that we will be adding AGPL as another license option next to ELv2 and SSPL in the coming weeks. 

https://www.elastic.co/pricing/faq/licensing (September 2025):
> In September 2024, we are adding the Open Source Initiative (OSI) approved AGPLv3 license as an option alongside SSPL and our Elastic license ensuring our community and customers have open source access to use, modify, redistribute, and collaborate on the code with a clear set of rights of their choice. Our releases will continue to be under the Elastic License.

https://www.elastic.co/licensing/elastic-license/faq:
> Can you summarize what is allowed with the Elastic License 2.0?
>
> The [Elastic License 2.0](https://www.elastic.co/licensing/elastic-license) applies to our distribution and the source code of all of the free and paid features of Elasticsearch and Kibana. Our goal with ELv2 is to be as permissive as possible, while protecting against abuse. The license allows the free right to use, modify, create derivative works, and redistribute, with three simple limitations:

>
> - You may not provide the products to others as a managed service 
> - You may not circumvent the license key functionality or remove/obscure features protected by license keys
> - You may not remove or obscure any licensing, copyright, or other notices

and

> I am building an application on top of Elasticsearch, how does ELv2 work for me?
>
> You may freely use Elasticsearch inside your SaaS or self-managed application, and redistribute it with your application, provided you follow the three limitations outlined above.

## Manual testing

- Removed all docker images, containers, volumes & builds to get a clean slate.
- Spun up the system with `docker compose up --build`.
- Ran all the data importers successfully i.e.
  ```bash
  docker compose exec sources python ingest_data administrative_division
  docker compose exec sources python ingest_data ontology_tree
  docker compose exec sources python ingest_data ontology_word
  docker compose exec sources python ingest_data location
  ```
- Ran the `sources` tests with `docker compose exec sources pytest` successfully.
- Installed `graphql` dependencies and ran its tests with successfully:
  ```bash
  cd graphql
  yarn
  yarn test:ci
  ```
Tried all the example GraphQL queries and the single Elasticsearch query given in the graphql app's README,
they all returned data.

## Related

[US-194](https://helsinkisolutionoffice.atlassian.net/browse/US-194)

[US-194]: https://helsinkisolutionoffice.atlassian.net/browse/US-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ